### PR TITLE
Add support for streamlined extensions, refs and dataPartition namespaces

### DIFF
--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/ConfigReaderTestCase.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/ConfigReaderTestCase.java
@@ -49,7 +49,7 @@ public class ConfigReaderTestCase {
     private static final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(ConfigReaderTestCase.class);
     private static final String DEFAULT_USER_NAME = "admin";
     private static final String DEFAULT_PASSWORD = "admin";
-    private static final String CARBON_YAML_FILENAME = "deployment.yaml";
+    static final String CARBON_YAML_FILENAME = "deployment.yaml";
 
     @Inject
     private CarbonServerInfo carbonServerInfo;
@@ -68,7 +68,7 @@ public class ConfigReaderTestCase {
     /**
      * Replace the existing deployment.yaml file with populated deployment.yaml file.
      */
-    private Option copyCarbonYAMLOption() {
+    public Option copyCarbonYAMLOption() {
         Path carbonYmlFilePath;
         String basedir = System.getProperty("basedir");
         if (basedir == null) {

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/NewConfigReaderTestCase.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/NewConfigReaderTestCase.java
@@ -17,26 +17,17 @@
  */
 package io.siddhi.distribution.test.osgi;
 
-import io.siddhi.distribution.test.osgi.util.HTTPResponseMessage;
-import io.siddhi.distribution.test.osgi.util.TestUtil;
-import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.ExamFactory;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.ops4j.pax.exam.testng.listener.PaxExam;
-import org.testng.Assert;
 import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
 import org.wso2.carbon.container.CarbonContainerFactory;
-import org.wso2.carbon.kernel.CarbonServerInfo;
 
-import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import javax.inject.Inject;
 
-import static org.wso2.carbon.container.options.CarbonDistributionOption.carbonDistribution;
 import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFile;
 
 /**
@@ -45,30 +36,12 @@ import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFil
 @Listeners(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 @ExamFactory(CarbonContainerFactory.class)
-public class NewConfigReaderTestCase {
-    private static final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(ConfigReaderTestCase.class);
-    private static final String DEFAULT_USER_NAME = "admin";
-    private static final String DEFAULT_PASSWORD = "admin";
-    private static final String CARBON_YAML_FILENAME = "deployment.yaml";
-
-    @Inject
-    private CarbonServerInfo carbonServerInfo;
-
-    @Configuration
-    public Option[] createConfiguration() {
-        logger.info("Running - " + this.getClass().getName());
-        return new Option[]{
-                copyCarbonYAMLOption(),
-                carbonDistribution(
-                        Paths.get("target", "siddhi-runner-" + System.getProperty("io.siddhi.distribution.version")),
-                        "runner")
-        };
-    }
-
+public class NewConfigReaderTestCase  extends ConfigReaderTestCase {
     /**
      * Replace the existing deployment.yaml file with populated deployment.yaml file.
      */
-    private Option copyCarbonYAMLOption() {
+    @Override
+    public Option copyCarbonYAMLOption() {
         Path carbonYmlFilePath;
         String basedir = System.getProperty("basedir");
         if (basedir == null) {
@@ -78,98 +51,4 @@ public class NewConfigReaderTestCase {
                 "conf", "configurationnew", CARBON_YAML_FILENAME);
         return copyFile(carbonYmlFilePath, Paths.get("conf", "runner", CARBON_YAML_FILENAME));
     }
-
-    @Test
-    public void testConfigReaderFunctionalityTest1() throws Exception {
-
-        URI baseURI = URI.create(String.format("http://%s:%d", "localhost", 9090));
-        String path = "/siddhi-apps";
-        String contentType = "text/plain";
-        String method = "POST";
-        String body = "@App:name('SiddhiApp1')\n" +
-                "@Store(ref='store4')" +
-                "define table FooTable (symbol string, price float, volume long);";
-
-        logger.info("Store reference support -  Configuring RDBMS extension");
-        HTTPResponseMessage httpResponseMessage = sendRequest(body, baseURI, path, contentType, method,
-                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
-        Assert.assertEquals(httpResponseMessage.getResponseCode(), 201);
-    }
-
-    @Test
-    public void testConfigReaderFunctionalityTest2() throws Exception {
-
-        URI baseURI = URI.create(String.format("http://%s:%d", "localhost", 9090));
-        String path = "/siddhi-apps";
-        String contentType = "text/plain";
-        String method = "POST";
-        String body = "@App:name('SiddhiApp3')\n" +
-                "@Store(ref='store1')" +
-                "define table FooTable (symbol string, price float, volume long);";
-
-        logger.info("Store reference support -  Configuring MongoDB extension");
-        HTTPResponseMessage httpResponseMessage = sendRequest(body, baseURI, path, contentType, method,
-                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
-        Assert.assertEquals(httpResponseMessage.getResponseCode(), 201);
-    }
-
-    @Test
-    public void testConfigReaderFunctionalityTest3() throws Exception {
-
-        URI baseURI = URI.create(String.format("http://%s:%d", "localhost", 9090));
-        String path = "/siddhi-apps";
-        String contentType = "text/plain";
-        String method = "POST";
-        String body = "@App:name('SiddhiApp4')\n" +
-                "@Store(ref='store3')" +
-                "define table FooTable (symbol string, price float, volume long);";
-
-        logger.info("Store reference support -  Configuring unknown extension");
-        HTTPResponseMessage httpResponseMessage = sendRequest(body, baseURI, path, contentType, method,
-                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
-        Assert.assertEquals(httpResponseMessage.getResponseCode(), 400);
-    }
-
-    @Test
-    public void testConfigReaderFunctionalityTest4() throws Exception {
-
-        URI baseURI = URI.create(String.format("http://%s:%d", "localhost", 9090));
-        String path = "/siddhi-apps";
-        String contentType = "text/plain";
-        String method = "POST";
-        String body = "@App:name('SiddhiApp5')\n" +
-                "@Store(ref='store8')" +
-                "define table FooTable (symbol string, price float, volume long);";
-
-        logger.info("Store reference support -  Configuring undefined store");
-        HTTPResponseMessage httpResponseMessage = sendRequest(body, baseURI, path, contentType, method,
-                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
-        Assert.assertEquals(httpResponseMessage.getResponseCode(), 400);
-    }
-
-    @Test
-    public void testConfigReaderFunctionalityTest5() throws Exception {
-
-        URI baseURI = URI.create(String.format("http://%s:%d", "localhost", 9090));
-        String path = "/siddhi-apps";
-        String contentType = "text/plain";
-        String method = "POST";
-        String body = "@App:name('SiddhiApp6')\n" +
-                "@Store(ref='store2')" +
-                "define table FooTable (symbol string, price float, volume long);";
-
-        logger.info("Store reference support -  Configuring with malformed store");
-        HTTPResponseMessage httpResponseMessage = sendRequest(body, baseURI, path, contentType, method,
-                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
-        Assert.assertEquals(httpResponseMessage.getResponseCode(), 400);
-    }
-
-    private HTTPResponseMessage sendRequest(String body, URI baseURI, String path, String contentType,
-                                            String methodType, Boolean auth, String userName, String password) {
-        TestUtil testUtil = new TestUtil(baseURI, path, auth, false, methodType,
-                contentType, userName, password);
-        testUtil.addBodyContent(body);
-        return testUtil.getResponse();
-    }
-
 }

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/NewConfigReaderTestCase.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/NewConfigReaderTestCase.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.distribution.test.osgi;
+
+import io.siddhi.distribution.test.osgi.util.HTTPResponseMessage;
+import io.siddhi.distribution.test.osgi.util.TestUtil;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.ExamFactory;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.ops4j.pax.exam.testng.listener.PaxExam;
+import org.testng.Assert;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+import org.wso2.carbon.container.CarbonContainerFactory;
+import org.wso2.carbon.kernel.CarbonServerInfo;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import javax.inject.Inject;
+
+import static org.wso2.carbon.container.options.CarbonDistributionOption.carbonDistribution;
+import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFile;
+
+/**
+ * Config Reader Test Case.
+ */
+@Listeners(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+@ExamFactory(CarbonContainerFactory.class)
+public class NewConfigReaderTestCase {
+    private static final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(ConfigReaderTestCase.class);
+    private static final String DEFAULT_USER_NAME = "admin";
+    private static final String DEFAULT_PASSWORD = "admin";
+    private static final String CARBON_YAML_FILENAME = "deployment.yaml";
+
+    @Inject
+    private CarbonServerInfo carbonServerInfo;
+
+    @Configuration
+    public Option[] createConfiguration() {
+        logger.info("Running - " + this.getClass().getName());
+        return new Option[]{
+                copyCarbonYAMLOption(),
+                carbonDistribution(
+                        Paths.get("target", "siddhi-runner-" + System.getProperty("io.siddhi.distribution.version")),
+                        "runner")
+        };
+    }
+
+    /**
+     * Replace the existing deployment.yaml file with populated deployment.yaml file.
+     */
+    private Option copyCarbonYAMLOption() {
+        Path carbonYmlFilePath;
+        String basedir = System.getProperty("basedir");
+        if (basedir == null) {
+            basedir = Paths.get(".").toString();
+        }
+        carbonYmlFilePath = Paths.get(basedir, "src", "test", "resources",
+                "conf", "configurationnew", CARBON_YAML_FILENAME);
+        return copyFile(carbonYmlFilePath, Paths.get("conf", "runner", CARBON_YAML_FILENAME));
+    }
+
+    @Test
+    public void testConfigReaderFunctionalityTest1() throws Exception {
+
+        URI baseURI = URI.create(String.format("http://%s:%d", "localhost", 9090));
+        String path = "/siddhi-apps";
+        String contentType = "text/plain";
+        String method = "POST";
+        String body = "@App:name('SiddhiApp1')\n" +
+                "@Store(ref='store4')" +
+                "define table FooTable (symbol string, price float, volume long);";
+
+        logger.info("Store reference support -  Configuring RDBMS extension");
+        HTTPResponseMessage httpResponseMessage = sendRequest(body, baseURI, path, contentType, method,
+                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
+        Assert.assertEquals(httpResponseMessage.getResponseCode(), 201);
+    }
+
+    @Test
+    public void testConfigReaderFunctionalityTest2() throws Exception {
+
+        URI baseURI = URI.create(String.format("http://%s:%d", "localhost", 9090));
+        String path = "/siddhi-apps";
+        String contentType = "text/plain";
+        String method = "POST";
+        String body = "@App:name('SiddhiApp3')\n" +
+                "@Store(ref='store1')" +
+                "define table FooTable (symbol string, price float, volume long);";
+
+        logger.info("Store reference support -  Configuring MongoDB extension");
+        HTTPResponseMessage httpResponseMessage = sendRequest(body, baseURI, path, contentType, method,
+                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
+        Assert.assertEquals(httpResponseMessage.getResponseCode(), 201);
+    }
+
+    @Test
+    public void testConfigReaderFunctionalityTest3() throws Exception {
+
+        URI baseURI = URI.create(String.format("http://%s:%d", "localhost", 9090));
+        String path = "/siddhi-apps";
+        String contentType = "text/plain";
+        String method = "POST";
+        String body = "@App:name('SiddhiApp4')\n" +
+                "@Store(ref='store3')" +
+                "define table FooTable (symbol string, price float, volume long);";
+
+        logger.info("Store reference support -  Configuring unknown extension");
+        HTTPResponseMessage httpResponseMessage = sendRequest(body, baseURI, path, contentType, method,
+                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
+        Assert.assertEquals(httpResponseMessage.getResponseCode(), 400);
+    }
+
+    @Test
+    public void testConfigReaderFunctionalityTest4() throws Exception {
+
+        URI baseURI = URI.create(String.format("http://%s:%d", "localhost", 9090));
+        String path = "/siddhi-apps";
+        String contentType = "text/plain";
+        String method = "POST";
+        String body = "@App:name('SiddhiApp5')\n" +
+                "@Store(ref='store8')" +
+                "define table FooTable (symbol string, price float, volume long);";
+
+        logger.info("Store reference support -  Configuring undefined store");
+        HTTPResponseMessage httpResponseMessage = sendRequest(body, baseURI, path, contentType, method,
+                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
+        Assert.assertEquals(httpResponseMessage.getResponseCode(), 400);
+    }
+
+    @Test
+    public void testConfigReaderFunctionalityTest5() throws Exception {
+
+        URI baseURI = URI.create(String.format("http://%s:%d", "localhost", 9090));
+        String path = "/siddhi-apps";
+        String contentType = "text/plain";
+        String method = "POST";
+        String body = "@App:name('SiddhiApp6')\n" +
+                "@Store(ref='store2')" +
+                "define table FooTable (symbol string, price float, volume long);";
+
+        logger.info("Store reference support -  Configuring with malformed store");
+        HTTPResponseMessage httpResponseMessage = sendRequest(body, baseURI, path, contentType, method,
+                true, DEFAULT_USER_NAME, DEFAULT_PASSWORD);
+        Assert.assertEquals(httpResponseMessage.getResponseCode(), 400);
+    }
+
+    private HTTPResponseMessage sendRequest(String body, URI baseURI, String path, String contentType,
+                                            String methodType, Boolean auth, String userName, String password) {
+        TestUtil testUtil = new TestUtil(baseURI, path, auth, false, methodType,
+                contentType, userName, password);
+        testUtil.addBodyContent(body);
+        return testUtil.getResponse();
+    }
+
+}

--- a/osgi-tests/src/test/resources/conf/configurationnew/deployment.yaml
+++ b/osgi-tests/src/test/resources/conf/configurationnew/deployment.yaml
@@ -1,0 +1,132 @@
+################################################################################
+#   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
+#
+#   Licensed under the Apache License, Version 2.0 (the \"License\");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an \"AS IS\" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+
+  # Carbon Configuration Parameters
+wso2.carbon:
+    # value to uniquely identify a server
+  id: wso2-sp
+    # server name
+  name: WSO2 Stream Processor
+    # ports used by this server
+  ports:
+      # port offset
+    offset: 0
+
+wso2.transport.http:
+  transportProperties:
+    -
+      name: "server.bootstrap.socket.timeout"
+      value: 60
+    -
+      name: "client.bootstrap.socket.timeout"
+      value: 60
+    -
+      name: "latency.metrics.enabled"
+      value: true
+
+  listenerConfigurations:
+    -
+      id: "default"
+      host: "0.0.0.0"
+      port: 9090
+    -
+      id: "msf4j-https"
+      host: "0.0.0.0"
+      port: 9443
+      scheme: https
+      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
+      keyStorePassword: wso2carbon
+      certPass: wso2carbon
+
+  senderConfigurations:
+    -
+      id: "http-sender"
+
+  # Periodic Persistence Configuration
+state.persistence:
+  enabled: false
+  intervalInMin: 1
+  revisionsToKeep: 2
+  persistenceStore: io.siddhi.distribution.core.persistence.FileSystemPersistenceStore
+  config:
+    location: siddhi-app-persistence
+
+  # Datasource Configurations
+wso2.datasources:
+  dataSources:
+    -
+      definition:
+        configuration:
+          connectionTestQuery: "SELECT 1"
+          driverClassName: org.h2.Driver
+          idleTimeout: 60000
+          isAutoCommit: false
+          jdbcUrl: "jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
+          maxPoolSize: 50
+          password: wso2carbon
+          username: wso2carbon
+          validationTimeout: 30000
+        type: RDBMS
+      description: "The datasource used for registry and user manager"
+      name: WSO2_CARBON_DB
+
+    # carbon metrics data source
+    - name: WSO2_METRICS_DB
+      description: The datasource used for dashboard feature
+      jndiConfig:
+        name: jdbc/WSO2MetricsDB
+      definition:
+        type: RDBMS
+        configuration:
+          jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/dashboard/database/metrics;AUTO_SERVER=TRUE'
+          username: wso2carbon
+          password: wso2carbon
+          driverClassName: org.h2.Driver
+          maxPoolSize: 50
+          idleTimeout: 60000
+          connectionTestQuery: SELECT 1
+          validationTimeout: 30000
+          isAutoCommit: false
+
+refs:
+  -
+    ref:
+      name: 'store1'
+      type: 'rdbms'
+      properties:
+        mongodb.uri: 'mongodb://localhost/Foo'
+  -
+    ref:
+      name: 'store2'
+      properties:
+        mongodb.uri: 'http://localhost:8080'
+
+  -
+    ref:
+      name: 'store3'
+      type: 'test'
+      properties:
+        mongodb.uri: 'http://localhost:8080'
+
+  -
+    ref:
+      name: 'store4'
+      type: 'rdbms'
+      properties:
+        jdbc.url: 'jdbc:h2:./target/dasdb'
+        username: 'root'
+        password: 'root'
+        jdbc.driver.name: 'org.h2.Driver'

--- a/osgi-tests/src/test/resources/testng.xml
+++ b/osgi-tests/src/test/resources/testng.xml
@@ -28,6 +28,7 @@ limitations under the License.
             <!--<class name="io.siddhi.distribution.test.osgi.FileSystemPersistenceStoreConfigTestcase"/>-->
 
             <class name="io.siddhi.distribution.test.osgi.ConfigReaderTestCase"/>
+            <class name="io.siddhi.distribution.test.osgi.NewConfigReaderTestCase"/>
             <class name="io.siddhi.distribution.test.osgi.SiddhiStoreAPITestcase"/>
             <class name="io.siddhi.distribution.test.osgi.SimulatorAPITestcase"/>
             <class name="io.siddhi.distribution.test.osgi.SiddhiToolingTestCase"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1134,7 +1134,7 @@
         <carbon.cache.version>1.1.3</carbon.cache.version>
         <carbon.touchpoint.version>1.1.1</carbon.touchpoint.version>
         <carbon.utils.version>2.0.9</carbon.utils.version>
-        <carbon.config.version>2.1.12</carbon.config.version>
+        <carbon.config.version>2.1.13</carbon.config.version>
         <carbon.config.version.range>[2.1.0, 3.0.0)</carbon.config.version.range>
         <carbon.securevault.version>5.0.14</carbon.securevault.version>
 

--- a/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/SPConstants.java
+++ b/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/SPConstants.java
@@ -25,6 +25,10 @@ public class SPConstants {
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String COOKIE_HEADER = "Cookie";
 
+    public static final String DATA_PARTITIONING_NAMESPACE = "dataPartition";
+    public static final String EXTENSIONS_NAMESPACE = "extensions";
+    public static final String REFS_NAMESPACE = "refs";
+
     private SPConstants() {
     }
 }

--- a/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/SPConstants.java
+++ b/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/SPConstants.java
@@ -25,7 +25,7 @@ public class SPConstants {
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String COOKIE_HEADER = "Cookie";
 
-    public static final String DATA_PARTITIONING_NAMESPACE = "dataPartition";
+    public static final String SIDDHI_PROPERTIES_NAMESPACE = "properties";
     public static final String EXTENSIONS_NAMESPACE = "extensions";
     public static final String REFS_NAMESPACE = "refs";
 

--- a/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/config/ExtensionsRootConfiguration.java
+++ b/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/config/ExtensionsRootConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c)  2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.distribution.common.common.utils.config;
+
+import org.wso2.carbon.config.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A third level configuration bean class for siddhi extension config.
+ */
+@Configuration(description = "Root element for extensions name space")
+public class ExtensionsRootConfiguration {
+
+    private List<Extension> extensions = new ArrayList<>();
+
+    public List<Extension> getExtensions() {
+        return extensions;
+    }
+
+}
+

--- a/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/config/FileConfigManager.java
+++ b/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/config/FileConfigManager.java
@@ -36,7 +36,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.siddhi.distribution.common.common.utils.SPConstants.DATA_PARTITIONING_NAMESPACE;
+import static io.siddhi.distribution.common.common.utils.SPConstants.SIDDHI_PROPERTIES_NAMESPACE;
 import static io.siddhi.distribution.common.common.utils.SPConstants.EXTENSIONS_NAMESPACE;
 import static io.siddhi.distribution.common.common.utils.SPConstants.REFS_NAMESPACE;
 
@@ -139,16 +139,16 @@ public class FileConfigManager implements ConfigManager {
         String property = null;
         if (configProvider != null) {
             try {
-                Object dataPartitioningConf = configProvider.getConfigurationObject(DATA_PARTITIONING_NAMESPACE);
-                LinkedHashMap dataPartitioningMap;
-                if (dataPartitioningConf == null || dataPartitioningConf instanceof Map) {
-                    dataPartitioningMap = ((LinkedHashMap) dataPartitioningConf);
-                    if (dataPartitioningMap != null && dataPartitioningMap.size() > 0) {
+                Object siddhiPropertiesConf = configProvider.getConfigurationObject(SIDDHI_PROPERTIES_NAMESPACE);
+                LinkedHashMap propertiesMap;
+                if (siddhiPropertiesConf == null || siddhiPropertiesConf instanceof Map) {
+                    propertiesMap = ((LinkedHashMap) siddhiPropertiesConf);
+                    if (propertiesMap != null && propertiesMap.size() > 0) {
                         if (LOGGER.isDebugEnabled()) {
                             LOGGER.debug("Matching property for name: '" + name + "' is looked for under name space '" +
-                                    DATA_PARTITIONING_NAMESPACE + "'.");
+                                    SIDDHI_PROPERTIES_NAMESPACE + "'.");
                         }
-                        property = dataPartitioningMap.get(name).toString();
+                        property = propertiesMap.get(name).toString();
                     } else {
                         RootConfiguration rootConfiguration =
                                 configProvider.getConfigurationObject(RootConfiguration.class);

--- a/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/config/FileConfigManager.java
+++ b/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/config/FileConfigManager.java
@@ -36,9 +36,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.siddhi.distribution.common.common.utils.SPConstants.SIDDHI_PROPERTIES_NAMESPACE;
 import static io.siddhi.distribution.common.common.utils.SPConstants.EXTENSIONS_NAMESPACE;
 import static io.siddhi.distribution.common.common.utils.SPConstants.REFS_NAMESPACE;
+import static io.siddhi.distribution.common.common.utils.SPConstants.SIDDHI_PROPERTIES_NAMESPACE;
 
 /**
  * Siddhi File Configuration Manager.

--- a/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/config/RefsRootConfiguration.java
+++ b/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/config/RefsRootConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c)  2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.distribution.common.common.utils.config;
+
+import org.wso2.carbon.config.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A third level configuration bean class for siddhi extension config.
+ */
+@Configuration(namespace = "refs", description = "References root configuration")
+public class RefsRootConfiguration {
+
+    private List<Reference> refs;
+
+    public RefsRootConfiguration() {
+        refs = new ArrayList<>();
+    }
+
+    public List<Reference> getRefs() {
+        return refs;
+    }
+
+}
+


### PR DESCRIPTION
## Purpose
$subject, sample as follows. Solves https://github.com/siddhi-io/distribution/issues/244
```
# Siddhi related properties
properties:
  partitionById: TRUE
  shardId: shard1

# Siddhi references
refs:
  - ref:
      name: source1
      type: store-type
      properties:
        property1: value1
        property2: value2

# Siddi Extensions system Parameters
extensions:
  - extension:
      name: rdbms
      namespace: store
      properties:
        mysql.batchEnable: true
        mysql.batchSize: 1000
        mysql.indexCreateQuery: "CREATE INDEX {{TABLE_NAME}}_INDEX ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})"
        mysql.recordDeleteQuery: "DELETE FROM {{TABLE_NAME}} {{CONDITION}}"
        mysql.recordExistsQuery: "SELECT 1 FROM {{TABLE_NAME}} {{CONDITION}} LIMIT 1"

```

## Goals
Support streamlined configurations

## Automation tests
 - Unit tests - N/A
 - Integration tests - Attached herewith

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes