### PR TITLE
 Add support for refs, extensions and properties namespace

### DIFF
--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/ConfigReaderTestCase2.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/ConfigReaderTestCase2.java
@@ -45,7 +45,7 @@ import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFil
 @Listeners(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 @ExamFactory(CarbonContainerFactory.class)
-public class NewConfigReaderTestCase {
+public class ConfigReaderTestCase2 {
     private static final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(ConfigReaderTestCase.class);
     private static final String DEFAULT_USER_NAME = "admin";
     private static final String DEFAULT_PASSWORD = "admin";

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/FileSystemPersistenceStoreConfigTestcase2.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/FileSystemPersistenceStoreConfigTestcase2.java
@@ -35,7 +35,7 @@ import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFil
 @Listeners(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 @ExamFactory(CarbonContainerFactory.class)
-public class FileSystemPersistenceStoreNewConfigTestcase extends FileSystemPersistenceStoreConfigTestcase {
+public class FileSystemPersistenceStoreConfigTestcase2 extends FileSystemPersistenceStoreConfigTestcase {
 
     /**
      * Replace the existing deployment.yaml file with populated deployment.yaml file.

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/NewConfigReaderTestCase.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/NewConfigReaderTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -9,7 +9,7 @@
  *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
- * software distributed under thhe License is distributed on an
+ * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
@@ -45,7 +45,7 @@ import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFil
 @Listeners(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 @ExamFactory(CarbonContainerFactory.class)
-public class ConfigReaderTestCase {
+public class NewConfigReaderTestCase {
     private static final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(ConfigReaderTestCase.class);
     private static final String DEFAULT_USER_NAME = "admin";
     private static final String DEFAULT_PASSWORD = "admin";
@@ -75,7 +75,7 @@ public class ConfigReaderTestCase {
             basedir = Paths.get(".").toString();
         }
         carbonYmlFilePath = Paths.get(basedir, "src", "test", "resources",
-                "conf", "configuration", CARBON_YAML_FILENAME);
+                "conf", "configurationnew", CARBON_YAML_FILENAME);
         return copyFile(carbonYmlFilePath, Paths.get("conf", "runner", CARBON_YAML_FILENAME));
     }
 
@@ -86,7 +86,7 @@ public class ConfigReaderTestCase {
         String path = "/siddhi-apps";
         String contentType = "text/plain";
         String method = "POST";
-        String body = "@App:name('SiddhiApp1')\n" +
+        String body = "@App:name('SiddhiApp11')\n" +
                 "@Store(ref='store4')" +
                 "define table FooTable (symbol string, price float, volume long);";
 
@@ -103,7 +103,7 @@ public class ConfigReaderTestCase {
         String path = "/siddhi-apps";
         String contentType = "text/plain";
         String method = "POST";
-        String body = "@App:name('SiddhiApp3')\n" +
+        String body = "@App:name('SiddhiApp13')\n" +
                 "@Store(ref='store1')" +
                 "define table FooTable (symbol string, price float, volume long);";
 
@@ -120,7 +120,7 @@ public class ConfigReaderTestCase {
         String path = "/siddhi-apps";
         String contentType = "text/plain";
         String method = "POST";
-        String body = "@App:name('SiddhiApp4')\n" +
+        String body = "@App:name('SiddhiApp14')\n" +
                 "@Store(ref='store3')" +
                 "define table FooTable (symbol string, price float, volume long);";
 
@@ -137,7 +137,7 @@ public class ConfigReaderTestCase {
         String path = "/siddhi-apps";
         String contentType = "text/plain";
         String method = "POST";
-        String body = "@App:name('SiddhiApp5')\n" +
+        String body = "@App:name('SiddhiApp15')\n" +
                 "@Store(ref='store8')" +
                 "define table FooTable (symbol string, price float, volume long);";
 
@@ -154,7 +154,7 @@ public class ConfigReaderTestCase {
         String path = "/siddhi-apps";
         String contentType = "text/plain";
         String method = "POST";
-        String body = "@App:name('SiddhiApp6')\n" +
+        String body = "@App:name('SiddhiApp16')\n" +
                 "@Store(ref='store2')" +
                 "define table FooTable (symbol string, price float, volume long);";
 
@@ -171,5 +171,4 @@ public class ConfigReaderTestCase {
         testUtil.addBodyContent(body);
         return testUtil.getResponse();
     }
-
 }

--- a/osgi-tests/src/test/resources/conf/configurationnew/deployment.yaml
+++ b/osgi-tests/src/test/resources/conf/configurationnew/deployment.yaml
@@ -1,0 +1,130 @@
+################################################################################
+#   Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
+#
+#   Licensed under the Apache License, Version 2.0 (the \"License\");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an \"AS IS\" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+
+  # Carbon Configuration Parameters
+wso2.carbon:
+    # value to uniquely identify a server
+  id: wso2-sp
+    # server name
+  name: WSO2 Stream Processor
+    # ports used by this server
+  ports:
+      # port offset
+    offset: 0
+
+wso2.transport.http:
+  transportProperties:
+    -
+      name: "server.bootstrap.socket.timeout"
+      value: 60
+    -
+      name: "client.bootstrap.socket.timeout"
+      value: 60
+    -
+      name: "latency.metrics.enabled"
+      value: true
+
+  listenerConfigurations:
+    -
+      id: "default"
+      host: "0.0.0.0"
+      port: 9090
+    -
+      id: "msf4j-https"
+      host: "0.0.0.0"
+      port: 9443
+      scheme: https
+      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
+      keyStorePassword: wso2carbon
+      certPass: wso2carbon
+
+  senderConfigurations:
+    -
+      id: "http-sender"
+
+  # Periodic Persistence Configuration
+state.persistence:
+  enabled: false
+  intervalInMin: 1
+  revisionsToKeep: 2
+  persistenceStore: io.siddhi.distribution.core.persistence.FileSystemPersistenceStore
+  config:
+    location: siddhi-app-persistence
+
+  # Datasource Configurations
+wso2.datasources:
+  dataSources:
+    -
+      definition:
+        configuration:
+          connectionTestQuery: "SELECT 1"
+          driverClassName: org.h2.Driver
+          idleTimeout: 60000
+          isAutoCommit: false
+          jdbcUrl: "jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
+          maxPoolSize: 50
+          password: wso2carbon
+          username: wso2carbon
+          validationTimeout: 30000
+        type: RDBMS
+      description: "The datasource used for registry and user manager"
+      name: WSO2_CARBON_DB
+
+    # carbon metrics data source
+    - name: WSO2_METRICS_DB
+      description: The datasource used for dashboard feature
+      jndiConfig:
+        name: jdbc/WSO2MetricsDB
+      definition:
+        type: RDBMS
+        configuration:
+          jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/dashboard/database/metrics;AUTO_SERVER=TRUE'
+          username: wso2carbon
+          password: wso2carbon
+          driverClassName: org.h2.Driver
+          maxPoolSize: 50
+          idleTimeout: 60000
+          connectionTestQuery: SELECT 1
+          validationTimeout: 30000
+          isAutoCommit: false
+
+refs:
+  -
+    ref:
+      name: 'store1'
+      type: 'rdbms'
+      properties:
+        mongodb.uri: 'mongodb://localhost/Foo'
+  -
+    ref:
+      name: 'store2'
+      properties:
+        mongodb.uri: 'http://localhost:8080'
+  -
+    ref:
+      name: 'store3'
+      type: 'test'
+      properties:
+        mongodb.uri: 'http://localhost:8080'
+  -
+    ref:
+      name: 'store4'
+      type: 'rdbms'
+      properties:
+        jdbc.url: 'jdbc:h2:./target/dasdb'
+        username: 'root'
+        password: 'root'
+        jdbc.driver.name: 'org.h2.Driver'

--- a/osgi-tests/src/test/resources/testng.xml
+++ b/osgi-tests/src/test/resources/testng.xml
@@ -29,6 +29,7 @@ limitations under the License.
             <!--<class name="io.siddhi.distribution.test.osgi.FileSystemPersistenceStoreConfigTestcase"/>-->
 
             <class name="io.siddhi.distribution.test.osgi.ConfigReaderTestCase"/>
+            <class name="io.siddhi.distribution.test.osgi.NewConfigReaderTestCase"/>
             <class name="io.siddhi.distribution.test.osgi.SiddhiStoreAPITestcase"/>
             <class name="io.siddhi.distribution.test.osgi.SimulatorAPITestcase"/>
             <class name="io.siddhi.distribution.test.osgi.SiddhiToolingTestCase"/>

--- a/osgi-tests/src/test/resources/testng.xml
+++ b/osgi-tests/src/test/resources/testng.xml
@@ -18,7 +18,7 @@ limitations under the License.
     <test name="siddhi-distribution-tests" preserve-order="true" parallel="false" thread-count="1">
         <classes>
             <class name="io.siddhi.distribution.test.osgi.FileSystemPersistenceStoreConfigTestcase"/>
-            <class name="io.siddhi.distribution.test.osgi.FileSystemPersistenceStoreNewConfigTestcase"/>
+            <class name="io.siddhi.distribution.test.osgi.FileSystemPersistenceStoreConfigTestcase2"/>
             <class name="io.siddhi.distribution.test.osgi.SiddhiAsAPITestcase"/>
             <class name="io.siddhi.distribution.test.osgi.SiddhiMetricsTestcase"/>
             <class name="io.siddhi.distribution.test.osgi.DBPersistenceStoreTestcase"/>
@@ -29,7 +29,7 @@ limitations under the License.
             <!--<class name="io.siddhi.distribution.test.osgi.FileSystemPersistenceStoreConfigTestcase"/>-->
 
             <class name="io.siddhi.distribution.test.osgi.ConfigReaderTestCase"/>
-            <class name="io.siddhi.distribution.test.osgi.NewConfigReaderTestCase"/>
+            <class name="io.siddhi.distribution.test.osgi.ConfigReaderTestCase2"/>
             <class name="io.siddhi.distribution.test.osgi.SiddhiStoreAPITestcase"/>
             <class name="io.siddhi.distribution.test.osgi.SimulatorAPITestcase"/>
             <class name="io.siddhi.distribution.test.osgi.SiddhiToolingTestCase"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1134,7 +1134,7 @@
         <carbon.cache.version>1.1.3</carbon.cache.version>
         <carbon.touchpoint.version>1.1.1</carbon.touchpoint.version>
         <carbon.utils.version>2.0.9</carbon.utils.version>
-        <carbon.config.version>2.1.13</carbon.config.version>
+        <carbon.config.version>2.1.14</carbon.config.version>
         <carbon.config.version.range>[2.1.0, 3.0.0)</carbon.config.version.range>
         <carbon.securevault.version>5.0.14</carbon.securevault.version>
 

--- a/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/SPConstants.java
+++ b/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/SPConstants.java
@@ -25,6 +25,10 @@ public class SPConstants {
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String COOKIE_HEADER = "Cookie";
 
+    public static final String SIDDHI_PROPERTIES_NAMESPACE = "properties";
+    public static final String EXTENSIONS_NAMESPACE = "extensions";
+    public static final String REFS_NAMESPACE = "refs";
+
     private SPConstants() {
     }
 }

--- a/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/config/FileConfigManager.java
+++ b/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/config/FileConfigManager.java
@@ -26,8 +26,14 @@ import org.wso2.carbon.config.ConfigurationException;
 import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.kernel.config.model.CarbonConfiguration;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import static io.siddhi.distribution.common.common.utils.SPConstants.EXTENSIONS_NAMESPACE;
+import static io.siddhi.distribution.common.common.utils.SPConstants.REFS_NAMESPACE;
+import static io.siddhi.distribution.common.common.utils.SPConstants.SIDDHI_PROPERTIES_NAMESPACE;
 
 /**
  * Siddhi File Configuration Manager.
@@ -36,88 +42,149 @@ public class FileConfigManager implements ConfigManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(FileConfigManager.class);
 
     private ConfigProvider configProvider;
+    private List<Extension> extensions;
+    private List<Reference> references;
+    private Map<String, String> properties;
 
     public FileConfigManager(ConfigProvider configProvider) {
         this.configProvider = configProvider;
     }
 
+    public void init() {
+        if (configProvider != null) {
+            initialiseExtensions();
+            initialiseReferences();
+            initaliseProperties();
+        } else {
+            extensions = new ArrayList<>();
+            references = new ArrayList<>();
+            properties = new HashMap<>();
+        }
+    }
+
+    private void initaliseProperties() {
+        // load siddhi properties
+        try {
+            Object siddhiPropertiesConf = configProvider.getConfigurationObject(SIDDHI_PROPERTIES_NAMESPACE);
+            HashMap propertiesMap;
+            if (siddhiPropertiesConf == null || siddhiPropertiesConf instanceof Map) {
+                propertiesMap = ((HashMap) siddhiPropertiesConf);
+                if (propertiesMap != null && propertiesMap.size() > 0) {
+                    this.properties = propertiesMap;
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("Matching siddhi property is looked for under name space '" +
+                                SIDDHI_PROPERTIES_NAMESPACE + "'.");
+                    }
+                } else {
+                    RootConfiguration rootConfiguration =
+                            configProvider.getConfigurationObject(RootConfiguration.class);
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("Matching siddhi property is looked for under name space " +
+                                "'siddhi.properties'.");
+                    }
+                    this.properties = rootConfiguration.getProperties();
+                }
+            } else {
+                throw new ConfigurationException("The first level under 'dataPartitioning' namespace should " +
+                        "be a map of type <sting, string>");
+            }
+        } catch (ConfigurationException e) {
+            LOGGER.error("Could not initiate the siddhi configuration object, " + e.getMessage(), e);
+            this.properties = new HashMap<>();
+        }
+    }
+
+    private void initialiseReferences() {
+        try {
+            ArrayList<Reference> references = configProvider
+                    .getConfigurationObjectList(REFS_NAMESPACE, Reference.class);
+            if (!references.isEmpty()) {
+                this.references = references;
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Matching references is loaded from under name space 'refs'.");
+                }
+            } else {
+                RootConfiguration rootConfiguration = configProvider
+                        .getConfigurationObject(RootConfiguration.class);
+                this.references = rootConfiguration.getRefs();
+                LOGGER.debug("Matching references is loaded from under name space 'siddhi.extensions'.");
+            }
+        } catch (Exception e) {
+            LOGGER.error("Could not initiate the refs configuration object, " + e.getMessage(), e);
+            this.references = new ArrayList<>();
+        }
+    }
+
+    private void initialiseExtensions() {
+        try {
+            // Process system configs
+            ArrayList<Extension> extensions = configProvider
+                    .getConfigurationObjectList(EXTENSIONS_NAMESPACE, Extension.class);
+            if (!extensions.isEmpty()) {
+                this.extensions = extensions;
+                LOGGER.debug("Matching extensions system configurations is loaded from under name space " +
+                        "'extensions'.");
+            } else {
+                RootConfiguration rootConfiguration = configProvider.
+                        getConfigurationObject(RootConfiguration.class);
+                this.extensions = rootConfiguration.getExtensions();
+                LOGGER.debug("Matching extensions system configurations is loaded from under name space " +
+                        "'siddhi.extensions'.");
+            }
+        } catch (Exception e) {
+            LOGGER.error("Could not initiate the extensions configuration object, " + e.getMessage(), e);
+            this.extensions = new ArrayList<>();
+        }
+    }
+
     @Override
     public ConfigReader generateConfigReader(String namespace, String name) {
-        if (configProvider != null) {
-            try {
-                RootConfiguration rootConfiguration = configProvider.getConfigurationObject(RootConfiguration.class);
-                if (null != rootConfiguration && null != rootConfiguration.getExtensions()) {
-                    for (Extension extension : rootConfiguration.getExtensions()) {
-                        ExtensionChildConfiguration childConfiguration = extension.getExtension();
-                        if (null != childConfiguration && null != childConfiguration.getName() && childConfiguration
-                                .getName().equals(name) && null != childConfiguration.getNamespace() &&
-                                childConfiguration.getNamespace().equals(namespace)
-                                && null != childConfiguration.getProperties()) {
-                            return new FileConfigReader(childConfiguration.getProperties());
-                        }
-                    }
-                }
-            } catch (ConfigurationException e) {
-                LOGGER.error("Could not initiate the siddhi configuration object, " + e.getMessage(), e);
+        for (Extension extension : this.extensions) {
+            ExtensionChildConfiguration childConfiguration = extension.getExtension();
+            if (childConfiguration.getNamespace().equals(namespace) &&
+                    childConfiguration.getName().equals(name) &&
+                    childConfiguration.getProperties() != null) {
+                return new FileConfigReader(childConfiguration.getProperties());
             }
         }
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Could not find a matching configuration for name: " +
-                    name + "and namespace: " + namespace + "!");
+            LOGGER.debug("Could not find a matching configuration for name: " + name + "and namespace: " +
+                    namespace + "!");
         }
         return new FileConfigReader(new HashMap<>());
     }
 
     @Override
     public Map<String, String> extractSystemConfigs(String name) {
-        if (configProvider != null) {
-            try {
-                RootConfiguration rootConfiguration = configProvider.getConfigurationObject(RootConfiguration.class);
-                if (null != rootConfiguration && null != rootConfiguration.getRefs()) {
-                    for (Reference ref : rootConfiguration.getRefs()) {
-                        ReferenceChildConfiguration childConfiguration = ref.getReference();
-                        if (null != childConfiguration && null != childConfiguration.getName()
-                                && childConfiguration.getName().equals(name)) {
-                            Map<String, String> referenceConfigs = new HashMap<>();
-                            referenceConfigs.put(SiddhiConstants.ANNOTATION_ELEMENT_TYPE, childConfiguration.getType());
-                            if (childConfiguration.getProperties() != null) {
-                                referenceConfigs.putAll(childConfiguration.getProperties());
-                            }
-                            return referenceConfigs;
-                        }
-                    }
+        for (Reference reference : references) {
+            ReferenceChildConfiguration childConf = reference.getReference();
+            if (childConf.getName().equals(name)) {
+                Map<String, String> referenceConfigs = new HashMap<>();
+                referenceConfigs.put(SiddhiConstants.ANNOTATION_ELEMENT_TYPE, childConf.getType());
+                if (childConf.getProperties() != null) {
+                    referenceConfigs.putAll(childConf.getProperties());
                 }
-            } catch (ConfigurationException e) {
-                LOGGER.error("Could not initiate the siddhi configuration object, " + e.getMessage(), e);
+                return referenceConfigs;
             }
+        }
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Could not find a matching reference for name: '" + name + "'!");
         }
         return new HashMap<>();
     }
 
     @Override
     public String extractProperty(String name) {
-        String property = null;
-        if (configProvider != null) {
+        String property = this.properties.get(name);
+        if (property == null && "shardId".equalsIgnoreCase(name)) {
             try {
-                RootConfiguration rootConfiguration =
-                        configProvider.getConfigurationObject(RootConfiguration.class);
-                if (null != rootConfiguration && null != rootConfiguration.getProperties()) {
-                    property = rootConfiguration.getProperties().get(name);
+                CarbonConfiguration carbonConfiguration =
+                        configProvider.getConfigurationObject(CarbonConfiguration.class);
+                if (carbonConfiguration != null && carbonConfiguration.getId() != null) {
+                    return carbonConfiguration.getId();
                 }
             } catch (ConfigurationException e) {
-                LOGGER.error("Could not initiate the siddhi configuration object, " + e.getMessage(), e);
-            }
-
-            if (property == null && "shardId".equalsIgnoreCase(name)) {
-                try {
-                    CarbonConfiguration carbonConfiguration =
-                            configProvider.getConfigurationObject(CarbonConfiguration.class);
-                    if (carbonConfiguration != null && carbonConfiguration.getId() != null) {
-                        return carbonConfiguration.getId();
-                    }
-                } catch (ConfigurationException e) {
-                    LOGGER.error("Could not initiate the wso2.carbon configuration object, " + e.getMessage(), e);
-                }
+                LOGGER.error("Could not initiate the wso2.carbon configuration object, " + e.getMessage(), e);
             }
         }
         if (LOGGER.isDebugEnabled()) {

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/internal/ServiceComponent.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/internal/ServiceComponent.java
@@ -93,6 +93,7 @@ public class ServiceComponent {
         StreamProcessorDataHolder.setStreamProcessorService(new StreamProcessorService());
         SiddhiManager siddhiManager = new SiddhiManager();
         FileConfigManager fileConfigManager = new FileConfigManager(configProvider);
+        fileConfigManager.init();
         siddhiManager.setConfigManager(fileConfigManager);
 
         PersistenceConfigurations persistenceConfigurations;

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
@@ -954,6 +954,7 @@ public class EditorMicroservice implements Microservice {
 
         try {
             FileConfigManager fileConfigManager = new FileConfigManager(configProvider);
+            fileConfigManager.init();
             SiddhiManager siddhiManager = new SiddhiManager();
             siddhiManager.setConfigManager(fileConfigManager);
             DesignGenerator designGenerator = new DesignGenerator();
@@ -1129,6 +1130,7 @@ public class EditorMicroservice implements Microservice {
         EditorDataHolder.setDebugProcessorService(new DebugProcessorService());
         SiddhiManager siddhiManager = new SiddhiManager();
         FileConfigManager fileConfigManager = new FileConfigManager(configProvider);
+        fileConfigManager.init();
         siddhiManager.setConfigManager(fileConfigManager);
         EditorDataHolder.setSiddhiManager(siddhiManager);
         EditorDataHolder.setBundleContext(bundleContext);


### PR DESCRIPTION
## Purpose
$subject
```
properties:
  partitionById: TRUE
  shardId: shard1

# Siddhi references
refs:
  - ref:
      name: source1
      type: store-type
      properties:
        property1: value1
        property2: value2

# Siddi Extensions system Parameters
extensions:
  - extension:
      name: rdbms
      namespace: store
      properties:
        mysql.batchEnable: true
        mysql.batchSize: 1000
        mysql.indexCreateQuery: "CREATE INDEX {{TABLE_NAME}}_INDEX ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})"
        mysql.recordDeleteQuery: "DELETE FROM {{TABLE_NAME}} {{CONDITION}}"
        mysql.recordExistsQuery: "SELECT 1 FROM {{TABLE_NAME}} {{CONDITION}} LIMIT 1"

```
Streamline config as discussed in https://groups.google.com/forum/?hl=en#!topic/siddhi-dev/j3W4mA8jjQ8 part of the task list in https://github.com/siddhi-io/distribution/issues/263

## Approach
As in 45623c6

## Documentation
N/A as it is backward compatible

## Automation tests
 - Unit tests - Attached herewith
 - Integration tests - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
