### PR TITLE
Bump MSF4J to 2.7.4

### DIFF
--- a/osgi-tests/src/test/resources/conf/configurationnew/deployment.yaml
+++ b/osgi-tests/src/test/resources/conf/configurationnew/deployment.yaml
@@ -25,38 +25,32 @@ wso2.carbon:
       # port offset
     offset: 0
 
-wso2.transport.http:
-  transportProperties:
-    -
-      name: "server.bootstrap.socket.timeout"
-      value: 60
-    -
-      name: "client.bootstrap.socket.timeout"
-      value: 60
-    -
-      name: "latency.metrics.enabled"
-      value: true
-
-  listenerConfigurations:
-    -
-      id: "default"
-      host: "0.0.0.0"
-      port: 9090
-    -
-      id: "msf4j-https"
-      host: "0.0.0.0"
-      port: 9443
-      scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
-
-  senderConfigurations:
-    -
-      id: "http-sender"
+transports:
+  http:
+    listenerConfigurations:
+      - id: "default"
+        host: "0.0.0.0"
+        port: 9090
+      - id: "msf4j-https"
+        host: "0.0.0.0"
+        port: 9443
+        scheme: https
+        keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
+        keyStorePassword: wso2carbon
+        certPass: wso2carbon
+    transportProperties:
+      -
+        name: "server.bootstrap.socket.timeout"
+        value: 60
+      -
+        name: "client.bootstrap.socket.timeout"
+        value: 60
+      -
+        name: "latency.metrics.enabled"
+        value: true
 
   # Periodic Persistence Configuration
-state.persistence:
+statePersistence:
   enabled: false
   intervalInMin: 1
   revisionsToKeep: 2
@@ -65,41 +59,40 @@ state.persistence:
     location: siddhi-app-persistence
 
   # Datasource Configurations
-wso2.datasources:
-  dataSources:
-    -
-      definition:
-        configuration:
-          connectionTestQuery: "SELECT 1"
-          driverClassName: org.h2.Driver
-          idleTimeout: 60000
-          isAutoCommit: false
-          jdbcUrl: "jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
-          maxPoolSize: 50
-          password: wso2carbon
-          username: wso2carbon
-          validationTimeout: 30000
-        type: RDBMS
-      description: "The datasource used for registry and user manager"
-      name: WSO2_CARBON_DB
+dataSources:
+  -
+    definition:
+      configuration:
+        connectionTestQuery: "SELECT 1"
+        driverClassName: org.h2.Driver
+        idleTimeout: 60000
+        isAutoCommit: false
+        jdbcUrl: "jdbc:h2:${sys:carbon.home}/wso2/${sys:wso2.runtime}/database/WSO2_CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
+        maxPoolSize: 50
+        password: wso2carbon
+        username: wso2carbon
+        validationTimeout: 30000
+      type: RDBMS
+    description: "The datasource used for registry and user manager"
+    name: WSO2_CARBON_DB
 
-    # carbon metrics data source
-    - name: WSO2_METRICS_DB
-      description: The datasource used for dashboard feature
-      jndiConfig:
-        name: jdbc/WSO2MetricsDB
-      definition:
-        type: RDBMS
-        configuration:
-          jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/dashboard/database/metrics;AUTO_SERVER=TRUE'
-          username: wso2carbon
-          password: wso2carbon
-          driverClassName: org.h2.Driver
-          maxPoolSize: 50
-          idleTimeout: 60000
-          connectionTestQuery: SELECT 1
-          validationTimeout: 30000
-          isAutoCommit: false
+  # carbon metrics data source
+  - name: WSO2_METRICS_DB
+    description: The datasource used for dashboard feature
+    jndiConfig:
+      name: jdbc/WSO2MetricsDB
+    definition:
+      type: RDBMS
+      configuration:
+        jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/dashboard/database/metrics;AUTO_SERVER=TRUE'
+        username: wso2carbon
+        password: wso2carbon
+        driverClassName: org.h2.Driver
+        maxPoolSize: 50
+        idleTimeout: 60000
+        connectionTestQuery: SELECT 1
+        validationTimeout: 30000
+        isAutoCommit: false
 
 refs:
   -

--- a/pom.xml
+++ b/pom.xml
@@ -1187,7 +1187,7 @@
         <javax.servlet.version>3.1.0</javax.servlet.version>
 
         <!--MSF4J related-->
-        <msf4j.version>2.7.3</msf4j.version>
+        <msf4j.version>2.7.4</msf4j.version>
         <com.fasterxml.jackson.core.version>2.9.9</com.fasterxml.jackson.core.version>
         <io.swagger.version>1.5.22</io.swagger.version>
         <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>

--- a/resources/carbon-home/conf/runner/deployment.yaml
+++ b/resources/carbon-home/conf/runner/deployment.yaml
@@ -25,35 +25,30 @@ wso2.carbon:
       # port offset
     offset: 0
 
-wso2.transport.http:
-  transportProperties:
-    -
-      name: "server.bootstrap.socket.timeout"
-      value: 60
-    -
-      name: "client.bootstrap.socket.timeout"
-      value: 60
-    -
-      name: "latency.metrics.enabled"
-      value: true
+transports:
+  http:
+    listenerConfigurations:
+      - id: "default"
+        host: "0.0.0.0"
+        port: 9090
+      - id: "msf4j-https"
+        host: "0.0.0.0"
+        port: 9443
+        scheme: https
+        keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
+        keyStorePassword: wso2carbon
+        certPass: wso2carbon
+    transportProperties:
+      -
+        name: "server.bootstrap.socket.timeout"
+        value: 60
+      -
+        name: "client.bootstrap.socket.timeout"
+        value: 60
+      -
+        name: "latency.metrics.enabled"
+        value: true
 
-  listenerConfigurations:
-    -
-      id: "default"
-      host: "0.0.0.0"
-      port: 9090
-    -
-      id: "msf4j-https"
-      host: "0.0.0.0"
-      port: 9443
-      scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
-
-  senderConfigurations:
-    -
-      id: "http-sender"
 
   # Datasource Configurations
 dataSources:

--- a/resources/carbon-home/conf/runner/deployment.yaml
+++ b/resources/carbon-home/conf/runner/deployment.yaml
@@ -28,16 +28,19 @@ wso2.carbon:
 transports:
   http:
     listenerConfigurations:
-      - id: "default"
+      -
+        id: "default"
         host: "0.0.0.0"
         port: 9090
-      - id: "msf4j-https"
+      -
+        id: "msf4j-https"
         host: "0.0.0.0"
         port: 9443
         scheme: https
         keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
         keyStorePassword: wso2carbon
         certPass: wso2carbon
+
     transportProperties:
       -
         name: "server.bootstrap.socket.timeout"

--- a/resources/carbon-home/conf/tooling/deployment.yaml
+++ b/resources/carbon-home/conf/tooling/deployment.yaml
@@ -28,16 +28,19 @@ wso2.carbon:
 transports:
   http:
     listenerConfigurations:
-      - id: "default"
+      -
+        id: "default"
         host: "0.0.0.0"
         port: 9390
-      - id: "msf4j-https"
+      -
+        id: "msf4j-https"
         host: "0.0.0.0"
         port: 9743
         scheme: https
         keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
         keyStorePassword: wso2carbon
         certPass: wso2carbon
+
     transportProperties:
       -
         name: "server.bootstrap.socket.timeout"

--- a/resources/carbon-home/conf/tooling/deployment.yaml
+++ b/resources/carbon-home/conf/tooling/deployment.yaml
@@ -25,35 +25,30 @@ wso2.carbon:
       # port offset
     offset: 3
 
-wso2.transport.http:
-  transportProperties:
-    -
-      name: "server.bootstrap.socket.timeout"
-      value: 60
-    -
-      name: "client.bootstrap.socket.timeout"
-      value: 60
-    -
-      name: "latency.metrics.enabled"
-      value: true
+transports:
+  http:
+    listenerConfigurations:
+      - id: "default"
+        host: "0.0.0.0"
+        port: 9390
+      - id: "msf4j-https"
+        host: "0.0.0.0"
+        port: 9743
+        scheme: https
+        keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
+        keyStorePassword: wso2carbon
+        certPass: wso2carbon
+    transportProperties:
+      -
+        name: "server.bootstrap.socket.timeout"
+        value: 60
+      -
+        name: "client.bootstrap.socket.timeout"
+        value: 60
+      -
+        name: "latency.metrics.enabled"
+        value: true
 
-  listenerConfigurations:
-    -
-      id: "default"
-      host: "0.0.0.0"
-      port: 9390
-    -
-      id: "msf4j-https"
-      host: "0.0.0.0"
-      port: 9743
-      scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
-
-  senderConfigurations:
-    -
-      id: "http-sender"
 
   # Datasource Configurations
 dataSources:


### PR DESCRIPTION
## Purpose
$subject to support transports>>http namespace
```
transports:
  http:
    listenerConfigurations:
      - 
        id: "default"
        host: "0.0.0.0"
        port: 9090
      - 
        id: "msf4j-https"
        host: "0.0.0.0"
        port: 9443
        scheme: https
        keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
        keyStorePassword: wso2carbon
        certPass: wso2carbon
    
    transportProperties:
      -
        name: "server.bootstrap.socket.timeout"
        value: 60
      -
        name: "client.bootstrap.socket.timeout"
        value: 60
      -
        name: "latency.metrics.enabled"
        value: true


```


## Goals
Streamline configs as discussed in  https://groups.google.com/forum/?hl=en#!topic/siddhi-dev/j3W4mA8jjQ8 as part of https://github.com/siddhi-io/distribution/issues/263

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes