### PR TITLE
Bump MSF4J

### DIFF
--- a/osgi-tests/src/test/resources/conf/configuration/deployment.yaml
+++ b/osgi-tests/src/test/resources/conf/configuration/deployment.yaml
@@ -47,9 +47,10 @@ wso2.transport.http:
       host: "0.0.0.0"
       port: 9443
       scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
+      sslConfig:
+        keyStore: "${carbon.home}/resources/security/wso2carbon.jks"
+        keyStorePass: wso2carbon
+        certPass: wso2carbon
 
   senderConfigurations:
     -

--- a/osgi-tests/src/test/resources/conf/configurationnew/deployment.yaml
+++ b/osgi-tests/src/test/resources/conf/configurationnew/deployment.yaml
@@ -35,9 +35,10 @@ transports:
         host: "0.0.0.0"
         port: 9443
         scheme: https
-        keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-        keyStorePassword: wso2carbon
-        certPass: wso2carbon
+        sslConfig:
+          keyStore: "${carbon.home}/resources/security/wso2carbon.jks"
+          keyStorePass: wso2carbon
+          certPass: wso2carbon
     transportProperties:
       -
         name: "server.bootstrap.socket.timeout"

--- a/osgi-tests/src/test/resources/conf/deployment.yaml
+++ b/osgi-tests/src/test/resources/conf/deployment.yaml
@@ -46,9 +46,10 @@ wso2.transport.http:
       host: "0.0.0.0"
       port: 9443
       scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
+      sslConfig:
+        keyStore: "${carbon.home}/resources/security/wso2carbon.jks"
+        keyStorePass: wso2carbon
+        certPass: wso2carbon
 
   senderConfigurations:
     -

--- a/osgi-tests/src/test/resources/conf/metrics/deployment.yaml
+++ b/osgi-tests/src/test/resources/conf/metrics/deployment.yaml
@@ -47,9 +47,10 @@ wso2.transport.http:
       host: "0.0.0.0"
       port: 9443
       scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
+      sslConfig:
+        keyStore: "${carbon.home}/resources/security/wso2carbon.jks"
+        keyStorePass: wso2carbon
+        certPass: wso2carbon
 
   senderConfigurations:
     -

--- a/osgi-tests/src/test/resources/conf/persistence/db/deployment-structure.yaml
+++ b/osgi-tests/src/test/resources/conf/persistence/db/deployment-structure.yaml
@@ -47,9 +47,10 @@ wso2.transport.http:
       host: "0.0.0.0"
       port: 9443
       scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
+      sslConfig:
+        keyStore: "${carbon.home}/resources/security/wso2carbon.jks"
+        keyStorePass: wso2carbon
+        certPass: wso2carbon
 
   senderConfigurations:
     -

--- a/osgi-tests/src/test/resources/conf/persistence/db/deployment.yaml
+++ b/osgi-tests/src/test/resources/conf/persistence/db/deployment.yaml
@@ -47,9 +47,10 @@ wso2.transport.http:
       host: "0.0.0.0"
       port: 9443
       scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
+      sslConfig:
+        keyStore: "${carbon.home}/resources/security/wso2carbon.jks"
+        keyStorePass: wso2carbon
+        certPass: wso2carbon
 
   senderConfigurations:
     -

--- a/osgi-tests/src/test/resources/conf/persistence/file/configTest/deployment.yaml
+++ b/osgi-tests/src/test/resources/conf/persistence/file/configTest/deployment.yaml
@@ -47,9 +47,10 @@ wso2.transport.http:
       host: "0.0.0.0"
       port: 9443
       scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
+      sslConfig:
+        keyStore: "${carbon.home}/resources/security/wso2carbon.jks"
+        keyStorePass: wso2carbon
+        certPass: wso2carbon
 
   senderConfigurations:
     -

--- a/osgi-tests/src/test/resources/conf/persistence/file/default/deployment.yaml
+++ b/osgi-tests/src/test/resources/conf/persistence/file/default/deployment.yaml
@@ -47,9 +47,10 @@ wso2.transport.http:
       host: "0.0.0.0"
       port: 9443
       scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
+      sslConfig:
+        keyStore: "${carbon.home}/resources/security/wso2carbon.jks"
+        keyStorePass: wso2carbon
+        certPass: wso2carbon
 
   senderConfigurations:
     -

--- a/osgi-tests/src/test/resources/conf/persistence/file/newConfigTest/deployment.yaml
+++ b/osgi-tests/src/test/resources/conf/persistence/file/newConfigTest/deployment.yaml
@@ -47,9 +47,10 @@ wso2.transport.http:
       host: "0.0.0.0"
       port: 9443
       scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
+      sslConfig:
+        keyStore: "${carbon.home}/resources/security/wso2carbon.jks"
+        keyStorePass: wso2carbon
+        certPass: wso2carbon
 
   senderConfigurations:
     -

--- a/osgi-tests/src/test/resources/conf/persistence/incremental-db/deployment-structure.yaml
+++ b/osgi-tests/src/test/resources/conf/persistence/incremental-db/deployment-structure.yaml
@@ -47,9 +47,10 @@ wso2.transport.http:
       host: "0.0.0.0"
       port: 9443
       scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
+      sslConfig:
+        keyStore: "${carbon.home}/resources/security/wso2carbon.jks"
+        keyStorePass: wso2carbon
+        certPass: wso2carbon
 
   senderConfigurations:
     -

--- a/osgi-tests/src/test/resources/conf/persistence/incremental-db/deployment.yaml
+++ b/osgi-tests/src/test/resources/conf/persistence/incremental-db/deployment.yaml
@@ -47,9 +47,10 @@ wso2.transport.http:
       host: "0.0.0.0"
       port: 9443
       scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
+      sslConfig:
+        keyStore: "${carbon.home}/resources/security/wso2carbon.jks"
+        keyStorePass: wso2carbon
+        certPass: wso2carbon
 
   senderConfigurations:
     -

--- a/osgi-tests/src/test/resources/conf/persistence/incremental-file/default/deployment.yaml
+++ b/osgi-tests/src/test/resources/conf/persistence/incremental-file/default/deployment.yaml
@@ -47,9 +47,10 @@ wso2.transport.http:
       host: "0.0.0.0"
       port: 9443
       scheme: https
-      keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-      keyStorePassword: wso2carbon
-      certPass: wso2carbon
+      sslConfig:
+        keyStore: "${carbon.home}/resources/security/wso2carbon.jks"
+        keyStorePass: wso2carbon
+        certPass: wso2carbon
 
   senderConfigurations:
     -

--- a/pom.xml
+++ b/pom.xml
@@ -1197,7 +1197,7 @@
         <javax.servlet.version>3.1.0</javax.servlet.version>
 
         <!--MSF4J related-->
-        <msf4j.version>2.7.5</msf4j.version>
+        <msf4j.version>2.8.0</msf4j.version>
         <com.fasterxml.jackson.core.version>2.9.9</com.fasterxml.jackson.core.version>
         <io.swagger.version>1.5.22</io.swagger.version>
         <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>

--- a/resources/carbon-home/conf/runner/deployment.yaml
+++ b/resources/carbon-home/conf/runner/deployment.yaml
@@ -37,9 +37,10 @@ transports:
         host: "0.0.0.0"
         port: 9443
         scheme: https
-        keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-        keyStorePassword: wso2carbon
-        certPass: wso2carbon
+        sslConfig:
+          keyStore: "${carbon.home}/resources/security/wso2carbon.jks"
+          keyStorePass: wso2carbon
+          certPass: wso2carbon
 
     transportProperties:
       -

--- a/resources/carbon-home/conf/runner/deployment.yaml
+++ b/resources/carbon-home/conf/runner/deployment.yaml
@@ -46,13 +46,6 @@ transports:
       -
         name: "server.bootstrap.socket.timeout"
         value: 60
-      -
-        name: "client.bootstrap.socket.timeout"
-        value: 60
-      -
-        name: "latency.metrics.enabled"
-        value: true
-
 
   # Datasource Configurations
 dataSources:

--- a/resources/carbon-home/conf/tooling/deployment.yaml
+++ b/resources/carbon-home/conf/tooling/deployment.yaml
@@ -37,9 +37,10 @@ transports:
         host: "0.0.0.0"
         port: 9740
         scheme: https
-        keyStoreFile: "${carbon.home}/resources/security/wso2carbon.jks"
-        keyStorePassword: wso2carbon
-        certPass: wso2carbon
+        sslConfig:
+          keyStore: "${carbon.home}/resources/security/wso2carbon.jks"
+          keyStorePass: wso2carbon
+          certPass: wso2carbon
 
     transportProperties:
       -

--- a/resources/carbon-home/conf/tooling/deployment.yaml
+++ b/resources/carbon-home/conf/tooling/deployment.yaml
@@ -46,13 +46,6 @@ transports:
       -
         name: "server.bootstrap.socket.timeout"
         value: 60
-      -
-        name: "client.bootstrap.socket.timeout"
-        value: 60
-      -
-        name: "latency.metrics.enabled"
-        value: true
-
 
   # Datasource Configurations
 dataSources:

--- a/resources/carbon-home/conf/transports/runner/netty-transports.yml
+++ b/resources/carbon-home/conf/transports/runner/netty-transports.yml
@@ -96,9 +96,10 @@ listenerConfigurations:
   host: "0.0.0.0"
   port: 9443
   scheme: https
-  keyStoreFile: ${carbon.home}/resources/security/wso2carbon.jks
-  keyStorePass: wso2carbon
-  certPass: wso2carbon
+  sslConfig:
+   keyStore: ${carbon.home}/resources/security/wso2carbon.jks
+   keyStorePass: wso2carbon
+   certPass: wso2carbon
   messageProcessorId: "MSF4J-CM-PROCESSOR"
 
 

--- a/resources/carbon-home/conf/transports/tooling/netty-transports.yml
+++ b/resources/carbon-home/conf/transports/tooling/netty-transports.yml
@@ -96,9 +96,10 @@ listenerConfigurations:
   host: "0.0.0.0"
   port: 9743
   scheme: https
-  keyStoreFile: ${carbon.home}/resources/security/wso2carbon.jks
-  keyStorePass: wso2carbon
-  certPass: wso2carbon
+  sslConfig:
+   keyStore: ${carbon.home}/resources/security/wso2carbon.jks
+   keyStorePass: wso2carbon
+   certPass: wso2carbon
   messageProcessorId: "MSF4J-CM-PROCESSOR"
 
 

--- a/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/service/SiddhiParserApi.java
+++ b/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/service/SiddhiParserApi.java
@@ -47,7 +47,7 @@ import org.wso2.carbon.config.ConfigurationException;
 import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.kernel.config.model.CarbonConfiguration;
 import org.wso2.msf4j.MicroservicesRunner;
-import org.wso2.msf4j.config.TransportsFileConfiguration;
+import org.wso2.transport.http.netty.contract.config.TransportsConfiguration;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -77,7 +77,7 @@ public class SiddhiParserApi {
     private static final Logger log = LoggerFactory.getLogger(SiddhiParserApi.class);
     private static final String TRANSPORT_ROOT_CONFIG_ELEMENT = "wso2.transport.http";
     private static final String SIDDHI_PARSER_ACTIVATION_SYS_PROPERTY = "siddhi-parser";
-    private static TransportsFileConfiguration transportsFileConfiguration;
+    private static TransportsConfiguration transportsConfiguration;
     private static MicroservicesRunner microservicesRunner;
     private static volatile boolean microserviceActive;
     private static SiddhiAppCreator appCreator = new NatsSiddhiAppCreator();
@@ -204,8 +204,8 @@ public class SiddhiParserApi {
      */
     @Activate
     protected void start(BundleContext bundleContext) throws Exception {
-        if (transportsFileConfiguration != null) {
-            microservicesRunner = new MicroservicesRunner(transportsFileConfiguration);
+        if (transportsConfiguration != null) {
+            microservicesRunner = new MicroservicesRunner(transportsConfiguration);
         }
         String toolIdentifier = System.getProperty(SIDDHI_PARSER_ACTIVATION_SYS_PROPERTY);
         Optional.ofNullable(toolIdentifier)
@@ -258,10 +258,10 @@ public class SiddhiParserApi {
     protected void registerConfigProvider(ConfigProvider configProvider) {
         SiddhiParserDataHolder.setConfigProvider(configProvider);
         try {
-            transportsFileConfiguration = configProvider.getConfigurationObject(TRANSPORT_ROOT_CONFIG_ELEMENT,
-                    TransportsFileConfiguration.class);
+            transportsConfiguration = configProvider.getConfigurationObject(TRANSPORT_ROOT_CONFIG_ELEMENT,
+                    TransportsConfiguration.class);
             CarbonConfiguration carbonConfig = configProvider.getConfigurationObject(CarbonConfiguration.class);
-            transportsFileConfiguration.getListenerConfigurations().forEach(
+            transportsConfiguration.getListenerConfigurations().forEach(
                     listenerConfiguration -> listenerConfiguration.setPort(
                             listenerConfiguration.getPort() + carbonConfig.getPortsConfig().getOffset()));
         } catch (ConfigurationException e) {


### PR DESCRIPTION
## Purpose
$subject.Due to the config changes in the MSF4J, configs under the transports >> http namespace will not be backward compatible. Following diff needs to be applied,
```diff
transports:
  http:
    listenerConfigurations:
-     keyStoreFile: src/test/resources/cert.jks
-     keyStorePass: wso2carbon
-     trustStoreFile: src/test/resources/cert-trust.jks
-     trustStorePass: wso2carbon 
-     validateCertEnabled: false
+    sslConfig:
+      keyStore: src/test/resources/cert.jks
+      keyStorePass: wso2carbon
+      trustStore: src/test/resources/cert-trust.jks
+      trustStorePass: wso2carbon
+      validateCertEnabled: false
```

## Goals
To use the latest dependency version.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
https://github.com/wso2/msf4j/pull/572

## Migrations (if applicable)
Configurations need to be updated to move all SSL related properties inside sslConfig element. Sample
```yaml
transports:
  http:
    listenerConfigurations:
      sslConfig:
        keyStore: src/test/resources/cert.jks
        keyStorePass: wso2carbon
        trustStore: src/test/resources/cert-trust.jks
        trustStorePass: wso2carbon
       validateCertEnabled: false
```

## Test environment
1.8.0_191
