### PR TITLE
Editor improvements related to OverloadParams & Design view

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -635,6 +635,11 @@
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
+            </dependency>
 
             <!-- JSON dependencies -->
             <dependency>
@@ -1149,6 +1154,7 @@
         <carbon.securevault.version>5.0.15</carbon.securevault.version>
 
         <!-- External Dependencies -->
+        <snakeyaml.version>1.23</snakeyaml.version>
         <slf4j.version>1.7.12</slf4j.version>
         <testng.version>6.14.3</testng.version>
         <antlr4.runtime.version>4.6.wso2v1</antlr4.runtime.version>

--- a/runner/components/io.siddhi.distribution.core/pom.xml
+++ b/runner/components/io.siddhi.distribution.core/pom.xml
@@ -156,6 +156,10 @@
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
         <!--analytics-common dependencies-->
         <dependency>
             <groupId>org.wso2.carbon.analytics-common</groupId>

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/constants.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/constants.js
@@ -99,6 +99,8 @@ define(function () {
         STREAM_FUNCTION: "stream-function",
         TYPE_HTTP_REQUEST: "http-request",
         TYPE_HTTP_RESPONSE: "http-response",
+        TYPE_CALL: "call",
+        TYPE_CALL_RESPONSE: "call-response",
         JOIN_QUERY_TITLE: "Join Query Configuration",
         AGGREGATION_TITLE: "Aggregation Configuration",
         APP_ANNOTATION_TITLE: "Siddhi App Configuration",

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/design-grid.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/design-grid.js
@@ -48,7 +48,10 @@ define(['require', 'log', 'jquery', 'backbone', 'lodash', 'designViewUtils', 'dr
             PARTITION: 'partitionDrop',
             PARTITION_CONNECTION_POINT: 'partition-connector-in-part',
             SELECTOR: 'selector',
-            MULTI_SELECTOR: 'multi-selector'
+            MULTI_SELECTOR: 'multi-selector',
+            TYPE_CALL: "call",
+            TYPE_CALL_RESPONSE: "call-response",
+            TYPE_HTTP_RESPONSE: "http-response"
         };
 
         /**
@@ -483,9 +486,19 @@ define(['require', 'log', 'jquery', 'backbone', 'lodash', 'designViewUtils', 'dr
                         if (sourceElement.hasClass(constants.SINK)) {
                             return connectionValidity = true;
                         }
-                        DesignViewUtils.prototype
-                            .errorAlert("Invalid Connection: http-request sink input source should be a " +
-                                "http-response source ");
+
+                        var sourceType = targetElement[0].textContent;
+                        if (sourceType === constants.TYPE_HTTP_RESPONSE) {
+                            DesignViewUtils.prototype
+                                .errorAlert("Invalid Connection: Input for the http-response source should be a " +
+                                    "http-request sink ");
+                        } else if (sourceType.endsWith(constants.TYPE_CALL_RESPONSE)) {
+                            DesignViewUtils.prototype
+                                .errorAlert("Invalid Connection: Input for the " + sourceType +
+                                    " source should be a " + sourceType.slice(0, sourceType.indexOf("-")) +
+                                    "call-request sink ");
+                        }
+
                         return connectionValidity;
                     }
 

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/drop-elements.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/drop-elements.js
@@ -1365,7 +1365,8 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
         };
 
         DropElements.prototype.generateSpecificSourceConnectionElements = function (type, jsPlumbInstance, i, element) {
-            if (type == Constants.TYPE_HTTP_RESPONSE) {
+            if (type === Constants.TYPE_HTTP_RESPONSE ||
+                (type !== undefined && type.endsWith(Constants.TYPE_CALL_RESPONSE))) {
                 var connectionIn = $('<div class="connectorInSource">').attr('id', i + "-in").addClass('connection');
                 element.append(connectionIn);
                 jsPlumbInstance.makeTarget(connectionIn, {
@@ -1382,7 +1383,8 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
         };
 
         DropElements.prototype.generateSpecificSinkConnectionElements = function (type, jsPlumbInstance, i, element) {
-            if (type == Constants.TYPE_HTTP_REQUEST) {
+            if (type === Constants.TYPE_HTTP_REQUEST ||
+                (type !== undefined && type.endsWith(Constants.TYPE_CALL))) {
                 var connectionOut = $('<div class="connectorOutSink">').attr('id', i + "-out").addClass('connection');
                 element.append(connectionOut);
                 jsPlumbInstance.makeSource(connectionOut, {

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/source-editor/utils.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/source-editor/utils.js
@@ -62,7 +62,7 @@ define(["./constants"], function (constants) {
      * @param {Object} paramOverloads Param overload array
      * @return {string} html string of the description generated from the meta data provided
      */
-    self.generateDescriptionForProcessor = function (metaData, processorName, paramOverloads) {
+    self.generateDescriptionForProcessor = function (metaData, processorTypeName, processorName, paramOverloads) {
         var description = "";
 
         if (processorName === undefined) {
@@ -83,14 +83,24 @@ define(["./constants"], function (constants) {
                     paramOverloads);
             }
         }
+
         if (metaData.returnAttributes) {
             description += "Return Attributes - " + generateAttributeListDescription(metaData.returnAttributes);
         }
+
         if (metaData.returnEvent) {
             description += (metaData.returnEvent.length > 0 ? "Additional Attributes in " : "") +
                 "Return Event" +
                 (metaData.returnEvent.length > 0 ? generateAttributeListDescription(metaData.returnEvent) : "");
         }
+
+        if (processorTypeName !== undefined) {
+            var processorTypeDisplayText = constants.typeToDisplayNameMap[processorTypeName];
+            if (processorTypeDisplayText !== undefined) {
+                description += "Type - " + processorTypeDisplayText;
+            }
+        }
+
         if (metaData.example) {
             description += "Example - <br><br>" +
                 "<span style='margin-left: 1em'>" + self.wordWrap(metaData.example) + "</span>";
@@ -247,16 +257,17 @@ define(["./constants"], function (constants) {
                     (attributeList[j].type.length > 0 ? " - " + attributeList[j].type.join(" | ").toUpperCase() : "") +
                     (attributeList[j].description ? " - " + attributeList[j].description : "") + "</li>";
             }
-            description += "</ul>";
+            description += "</ul><br>";
         } else {
             description += "none<br><br>";
         }
+
         return description;
     }
 
     function generateAttributeListDescriptionForParamOverloads(attributeList, paramOverloads) {
         var description = "";
-        if (attributeList.length > 0) {
+        if (attributeList.length > 0 && paramOverloads.length > 0) {
             description += "<ul>";
             for (var j = 0; j < attributeList.length; j++) {
                 var attributeName = attributeList[j].name;
@@ -268,10 +279,11 @@ define(["./constants"], function (constants) {
                         (attributeList[j].description ? " - " + attributeList[j].description : "") + "</li>";
                 }
             }
-            description += "</ul>";
+            description += "</ul><br>";
         } else {
             description += "none<br><br>";
         }
+
         return description;
     }
 

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/source-editor/utils.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/source-editor/utils.js
@@ -58,16 +58,30 @@ define(["./constants"], function (constants) {
      * Descriptions are intended to be shown in the tooltips for completions
      *
      * @param {Object} metaData Meta data object containing parameters, return and description
+     * @param {string} processorName Processor Name with overload params
+     * @param {Object} paramOverloads Param overload array
      * @return {string} html string of the description generated from the meta data provided
      */
-    self.generateDescriptionForProcessor = function (metaData) {
-        var description = "<div>" + (metaData.name ? "<strong>" + metaData.name + "</strong><br>" : "");
+    self.generateDescriptionForProcessor = function (metaData, processorName, paramOverloads) {
+        var description = "";
+
+        if (processorName === undefined) {
+            description = "<div>" + (metaData.name ? "<strong>" + metaData.name + "</strong><br>" : "");
+        } else {
+            description = "<div>" + (metaData.name ? "<strong>" + processorName + "</strong><br>" : "");
+        }
+
         if (metaData.description) {
             description +=
                 metaData.description ? "<p>" + metaData.description + "</p>" : "<br>";
         }
         if (metaData.parameters) {
-            description += "Parameters - " + generateAttributeListDescription(metaData.parameters);
+            if(paramOverloads === undefined) {
+                description += "Parameters - " + generateAttributeListDescription(metaData.parameters);
+            } else {
+                description += "Parameters - " + generateAttributeListDescriptionForParamOverloads(metaData.parameters,
+                    paramOverloads);
+            }
         }
         if (metaData.returnAttributes) {
             description += "Return Attributes - " + generateAttributeListDescription(metaData.returnAttributes);
@@ -227,10 +241,32 @@ define(["./constants"], function (constants) {
         if (attributeList.length > 0) {
             description += "<ul>";
             for (var j = 0; j < attributeList.length; j++) {
-                description += "<li>" + (attributeList[j].name ? attributeList[j].name : "Attribute " + (j + 1)) +
+                description += "<li><b>" +
+                    (attributeList[j].name ? attributeList[j].name : "Attribute " + (j + 1)) + "</b>" +
                     (attributeList[j].optional ? " (optional)" : "") +
                     (attributeList[j].type.length > 0 ? " - " + attributeList[j].type.join(" | ").toUpperCase() : "") +
                     (attributeList[j].description ? " - " + attributeList[j].description : "") + "</li>";
+            }
+            description += "</ul>";
+        } else {
+            description += "none<br><br>";
+        }
+        return description;
+    }
+
+    function generateAttributeListDescriptionForParamOverloads(attributeList, paramOverloads) {
+        var description = "";
+        if (attributeList.length > 0) {
+            description += "<ul>";
+            for (var j = 0; j < attributeList.length; j++) {
+                var attributeName = attributeList[j].name;
+                if(paramOverloads.includes(attributeName)) {
+                    description += "<li><b>" + attributeName + "</b>" +
+                        (attributeList[j].optional ? " (optional)" : "") +
+                        (attributeList[j].type.length > 0 ? " - " + attributeList[j].type.join(" | ").
+                        toUpperCase() : "") +
+                        (attributeList[j].description ? " - " + attributeList[j].description : "") + "</li>";
+                }
             }
             description += "</ul>";
         } else {


### PR DESCRIPTION
## Purpose
This PR contain below improvements and bug fixes.
> Add overload param support for source view editor 
<img width="1432" alt="Screen Shot 2019-08-19 at 6 01 21 PM" src="https://user-images.githubusercontent.com/7523274/63265585-95cdcf00-c2ab-11e9-8ca3-3f4a15464a91.png">

> Improve design view to show the connection between *-call-request and *-call-response IOs.

<img width="736" alt="Screen Shot 2019-08-19 at 6 02 38 PM" src="https://user-images.githubusercontent.com/7523274/63265641-ba29ab80-c2ab-11e9-8671-14de5929cd15.png">

> Fix for snakeyaml dependency issue.