### PR TITLE
Enable editor microservice to support docker export

### DIFF
--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/request/ExportAppsRequest.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/request/ExportAppsRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)  2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c)  2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -25,11 +25,11 @@ import java.util.Map;
  * Bean class to represent the docker and K8s download request payload.
  */
 public class ExportAppsRequest {
-    Map<String, String> siddhiApps;
-    String configuration;
-    Map<String, String> variables;
-    List<String> bundles;
-    List<String> jars;
+    private Map<String, String> siddhiApps;
+    private String configuration;
+    private Map<String, String> templatedVariables;
+    private List<String> bundles;
+    private List<String> jars;
 
     public Map<String, String> getSiddhiApps() {
         return siddhiApps;
@@ -39,8 +39,8 @@ public class ExportAppsRequest {
         return configuration;
     }
 
-    public Map<String, String> getVariables() {
-        return variables;
+    public Map<String, String> getTemplatedVariables() {
+        return templatedVariables;
     }
 
     public List<String> getBundles() {

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
@@ -1051,7 +1051,7 @@ public class EditorMicroservice implements Microservice {
     @POST
     @Path("/export")
     public Response exportApps(@QueryParam("type") String exportType, ExportAppsRequest exportAppsRequest) {
-        DockerUtils dockerUtils = new DockerUtils(exportAppsRequest);
+        DockerUtils dockerUtils = new DockerUtils(configProvider, exportAppsRequest);
         try {
             File zipFile = dockerUtils.createZipFile();
             return Response

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
@@ -1043,7 +1043,7 @@ public class EditorMicroservice implements Microservice {
     }
 
     /**
-     * Export given Siddhi apps and other configurations to docker or kubernetes artifacts
+     * Export given Siddhi apps and other configurations to docker or kubernetes artifacts.
      *
      * @param exportType Export type (docker or kubernetes
      * @return Docker or Kubernetes artifacts

--- a/tooling/features/io.siddhi.distribution.editor.core.feature/src/main/resources/docker-export/Dockerfile
+++ b/tooling/features/io.siddhi.distribution.editor.core.feature/src/main/resources/docker-export/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # use siddhi-runner-base
-FROM siddhiio/siddhi-runner-base-alpine:5.1.0-m2
+FROM siddhiio/siddhi-runner-base-alpine:{{PRODUCT_VERSION}}
 MAINTAINER Siddhi IO Docker Maintainers "siddhi-dev@googlegroups.com"
 
 ARG HOST_BUNDLES_DIR=./bundles


### PR DESCRIPTION
## Purpose
Resolve #247

## Goals
As the initial step of the backend, here adding a microservice to export Siddhi apps to a docker artifact.

## Approach
Here we added a microservice which consume following JSON as a POST request.
```json
{
   "siddhiApps":{
      "ReceiveAndCount":"@App:name(\"ReceiveAndCount\")\n@App:description('Receive events via HTTP transport and view the output on the console')\n\n@Source(type = 'http',\n        receiver.url='${url}',\n        basic.auth.enabled='false',\n        @map(type='json'))\ndefine stream SweetProductionStream (name string, amount double);\n\n@sink(type='log')\ndefine stream TotalCountStream (totalCount long);\n\n-- Count the incoming events\n@info(name='query1')\nfrom SweetProductionStream\nselect count() as totalCount\ninsert into TotalCountStream;"
   },
   "configuration":"state.persistence:\n  enabled: true\n  intervalInMin: 1\n  revisionsToKeep: 2\n  persistenceStore: io.siddhi.distribution.core.persistence.FileSystemPersistenceStore\n  config:\n    location: siddhi-app-persistence",
   "variables":{
   		"url": "http://0.0.0.0:8081/test"
   },
   "bundles":[
   		"siddhi-execution-regex-5.0.6-20190822.080623-23.jar"
    ],
    "jars":[
    	"siddhi-execution-reorder-5.0.4-20190822.080708-23.jar",
    	"siddhi-execution-math-5.0.4-20190822.080625-23.jar"
    ],
   "kubernetesConfiguration":""
}
```
Then microservice will generate a zip file(`siddhi-docker.zip`) like below.
```sh
├── Dockerfile
├── bundles
│   └── siddhi-execution-regex-5.0.6-20190822.080623-23.jar
├── configurations.yaml
├── jars
│   ├── siddhi-execution-math-5.0.4-20190822.080625-23.jar
│   └── siddhi-execution-reorder-5.0.4-20190822.080708-23.jar
└── siddhi-files
    └── ReceiveAndCount.siddhi
```
That zip file contained the following sub-files.
1. Dockerfile - docker file that exported
1. bundles - additional bundles that used in Siddhi tooling
1. jars - additional jars that used in Siddhi tooling
1. configurations.yaml - config file if the user wants to do some modifications to the default `deployment.yaml` file in tooling.
1. siddhi-files - Siddhi files that the user wants to deploy in the docker container.

## Test environment
java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)