### PR TITLE
Change clusterId spec to streamingClusterId in parser

### DIFF
--- a/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/service/model/MessagingConfig.java
+++ b/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/service/model/MessagingConfig.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
  */
 public class MessagingConfig {
 
-    @SerializedName("clusterId")
+    @SerializedName("streamingClusterId")
     private String clusterId;
 
     @SerializedName("bootstrapServers")


### PR DESCRIPTION
## Purpose
https://github.com/siddhi-io/siddhi-operator/issues/82

## Goals
Change messaging config to be more descriptive.

## Approach
Change the messaging config spec. Here change the previous `clusterId` to `streamingClusterId`. New messaging config is like below.
```yaml
  messagingSystem:
    type: nats
    config: 
      bootstrapServers: 
        - "nats://nats-siddhi:4222"
      streamingClusterId: stan-siddhi
```

## Related PRs
https://github.com/siddhi-io/siddhi-operator/pull/84

## Test environment
Java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)
Minikube version: v1.2.0