### PR TITLE
Fix JSON request compatibility with frontend

### DIFF
--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/request/ExportAppsRequest.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/request/ExportAppsRequest.java
@@ -25,22 +25,22 @@ import java.util.Map;
  * Bean class to represent the docker and K8s download request payload.
  */
 public class ExportAppsRequest {
-    private Map<String, String> siddhiApps;
+    private List<Map<String, String>> templatedSiddhiApps;
     private String configuration;
-    private Map<String, String> templatedVariables;
+    private List<Map<String, String>> templatedVariables;
     private List<String> bundles;
     private List<String> jars;
     private String kubernetesConfiguration;
 
-    public Map<String, String> getSiddhiApps() {
-        return siddhiApps;
+    public List<Map<String, String>> getTemplatedSiddhiApps() {
+        return templatedSiddhiApps;
     }
 
     public String getConfiguration() {
         return configuration;
     }
 
-    public Map<String, String> getTemplatedVariables() {
+    public List<Map<String, String>> getTemplatedVariables() {
         return templatedVariables;
     }
 


### PR DESCRIPTION
## Purpose
Resolve #247. 

## Goals
Fix the `/export` service which exports Siddhi applications to docker and kubernetes artifacts. Fix the following issues.
- Empty response when kubernetes configurations is an empty string.
- Compatibility issue with frontend.
- Returning a tooling config block when calling the `/deploymentConfigs` microservice.

## Approach
Here fix some compatibility issues with frontend. Change Siddhi app and templated variables specs as defined in the following request.

### Request
```json
{
	"templatedSiddhiApps": [{
			"appName": "PowerConsumptionSurgeDetection",
			"appContent": "@App:name(\"ReceiveAndCount\")\n\n@source(\n    type='http',\n    receiver.url='${RECEIVER_URL}',\nbasic.auth.enabled='${BASIC_AUTH_ENABLED}',\n    @map(type='json')\n)\ndefine stream DevicePowerStream(deviceType string, power int);\n\n@sink(type='log')\ndefine stream PowerSurgeAlertStream(deviceType string, powerConsumed long);\n\n@info(name='surge-detector')\nfrom DevicePowerStream#window.time(1 min)\nselect deviceType, sum(power) as powerConsumed\ngroup by deviceType\nhaving powerConsumed > 10000\noutput every 30 sec\ninsert into PowerSurgeAlertStream;"
		},
		{
			"appName": "PowerConsumptionSurgeDetection1",
			"appContent": "@App:name(\"ReceiveAndCount\")\n\n@source(\n    type='http',\n    receiver.url='${RECEIVER_URL}',\nbasic.auth.enabled='${BASIC_AUTH_ENABLED}',\n    @map(type='json')\n)\ndefine stream DevicePowerStream(deviceType string, power int);\n\n@sink(type='log')\ndefine stream PowerSurgeAlertStream(deviceType string, powerConsumed long);\n\n@info(name='surge-detector')\nfrom DevicePowerStream#window.time(1 min)\nselect deviceType, sum(power) as powerConsumed\ngroup by deviceType\nhaving powerConsumed > 10000\noutput every 30 sec\ninsert into PowerSurgeAlertStream;"
		}
	],
	"configuration": "state.persistence:\n  enabled: true\n  intervalInMin: 1\n  revisionsToKeep: 2\n  persistenceStore: io.siddhi.distribution.core.persistence.FileSystemPersistenceStore\n  config:\n    location: siddhi-app-persistence",
	"templatedVariables": [{
			"key": "RECEIVER_URL",
			"value": "http://0.0.0.0:8080/checkPower"
		},
		{
			"key": "BASIC_AUTH_ENABLED",
			"value": "false"
		}
	],
	"kubernetesConfiguration": "siddhiProcessName: power-app\nmessagingSystem:\n  type: nats\n\npersistentVolumeClaim:\n  accessModes:\n    - ReadWriteOnce\n  resources:\n    requests:\n      storage: 1Gi\n  storageClassName: standard\n  volumeMode: Filesystem"
}
```

There is no structural change in the response format.

## Related PRs
- #329 
- #335 
- #340 

## Test environment
Java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)