### PR TITLE
[Tooling][Export feature]Skip empty jar/bundle selections

### DIFF
--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/export-artifacts/jars-selector-dialog.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/export-artifacts/jars-selector-dialog.js
@@ -49,7 +49,7 @@ define(['jquery', 'lodash', 'log', 'file_browser', /** void module - jquery plug
             var bundles = [];
             var files = this.bundlesBrowser.getBottomSelected();
             for (var i = 0; i < files.length; i++) {
-                if (files[i].id.startsWith(directoryName)) {
+                if (files[i].id != directoryName && files[i].id.startsWith(directoryName)) {
                     var fileName = _.last(files[i].id.split(this.pathSeparator));
                     bundles.push(fileName);
 


### PR DESCRIPTION
## Purpose
> While using docker/k8 export feature, at the jar selection step, if you select the jars/bundles empty directory, directory name would be appended as an entry. We need to skip that case.