### PR TITLE
Change export file names and replace init script from the Dockerfile

### DIFF
--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
@@ -138,6 +138,7 @@ public class EditorMicroservice implements Microservice {
     private static final String FILE_SEPARATOR = "file.separator";
     private static final String STATUS = "status";
     private static final String SUCCESS = "success";
+    private static final String EXPORT_TYPE_KUBERNETES = "kubernetes";
     private ServiceRegistration serviceRegistration;
     private Workspace workspace;
     private ExecutorService executorService = Executors
@@ -1117,10 +1118,16 @@ public class EditorMicroservice implements Microservice {
             ExportAppsRequest exportAppsRequest = new Gson().fromJson(payload, ExportAppsRequest.class);
             ExportUtils exportUtils = new ExportUtils(configProvider, exportAppsRequest, exportType);
             File zipFile = exportUtils.createZipFile();
+            String fileName = "siddhi-docker.zip";
+            if (exportType != null) {
+                if (exportType.equals(EXPORT_TYPE_KUBERNETES)) {
+                    fileName = "siddhi-kubernetes.zip";
+                }
+            }
             return Response
                     .status(Response.Status.OK)
                     .entity(zipFile)
-                    .header("Content-Disposition", "attachment; filename=siddhi-docker.zip")
+                    .header("Content-Disposition", ("attachment; filename=" + fileName))
                     .build();
         } catch (JsonSyntaxException e) {
             log.error("Incorrect configuration format.", e);

--- a/tooling/features/io.siddhi.distribution.editor.core.feature/src/main/resources/docker-export/Dockerfile
+++ b/tooling/features/io.siddhi.distribution.editor.core.feature/src/main/resources/docker-export/Dockerfile
@@ -40,8 +40,6 @@ COPY --chown=siddhi_user:siddhi_io ${HOST_APPS_DIR}/ ${APPS}
 # expose ports
 EXPOSE 9090 9443 9712 9612 7711 7611 7070 7443
 
-RUN bash ${RUNTIME_SERVER_HOME}/bin/install-jars.sh
-
 STOPSIGNAL SIGINT
 
-ENTRYPOINT ["/home/siddhi_user/init.sh" {{CONFIGURATION_PARAMETER_BLOCK}}]
+ENTRYPOINT ["/home/siddhi_user/siddhi-runner/bin/runner.sh" {{CONFIGURATION_PARAMETER_BLOCK}}]


### PR DESCRIPTION
## Purpose
Resolve #378.

##  Goals
- Change the name of the exported zip file according to the export type
- Fix Dockerfile build problem of unable to find init.sh file

## Approach
- Escape $ character in a single step
- Change the export file name according to the request type
- Remove unwanted init.sh running script from the Dockerfile and add runner.sh script
- Remove environmental variable from entry point of the Dockerfile and add `-Dconfig=/home/siddhi_user/configurations.yaml`

## User stories
- When user export as docker it will download siddhi-docker.zip
- When user export as K8s it will download siddhi-kubernetes.zip

## Related PRs
- https://github.com/siddhi-io/distribution/pull/329

## Test environment
Java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)
Java HotSpot(TM) 64-Bit Server VM (build 25.201-b09, mixed mode)