### PR TITLE
Remove unwanted app copy and set default SiddhiProcess name in K8s export

### DIFF
--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/ExportUtils.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/ExportUtils.java
@@ -64,6 +64,7 @@ public class ExportUtils {
     private static final String JARS_BLOCK_TEMPLATE = "\\{\\{JARS_BLOCK}}";
     private static final String BUNDLES_BLOCK_TEMPLATE = "\\{\\{BUNDLES_BLOCK}}";
     private static final String ENV_BLOCK_TEMPLATE = "\\{\\{ENV_BLOCK}}";
+    private static final String APPS_BLOCK_TEMPLATE = "\\{\\{APPS_BLOCK}}";
     private static final String PRODUCT_VERSION_TEMPLATE = "\\{\\{PRODUCT_VERSION}}";
     private static final String CONFIG_BLOCK_VALUE =
             "COPY --chown=siddhi_user:siddhi_io \\$\\{CONFIG_FILE}/ \\$\\{USER_HOME}";
@@ -73,6 +74,8 @@ public class ExportUtils {
             "COPY --chown=siddhi_user:siddhi_io \\$\\{HOST_JARS_DIR}/ \\$\\{JARS}";
     private static final String BUNDLES_BLOCK_VALUE =
             "COPY --chown=siddhi_user:siddhi_io \\$\\{HOST_BUNDLES_DIR}/ \\$\\{BUNDLES}";
+    private static final String APPS_BLOCK_VALUE =
+            "COPY --chown=siddhi_user:siddhi_io \\$\\{HOST_APPS_DIR}/ \\$\\{APPS}";
     private static final String SIDDHI_PROCESS_SPEC_TEMPLATE = "\\{\\{SIDDHI_PROCESS_SPEC}}";
     private static final String SIDDHI_PROCESS_NAME_TEMPLATE = "\\{\\{SIDDHI_PROCESS_NAME}}";
     private static final String SIDDHI_PROCESS_DEFAULT_NAME = "sample-siddhi-process";
@@ -301,6 +304,13 @@ public class ExportUtils {
         String content = new String(data, StandardCharsets.UTF_8);
         String productVersion = this.getConfigurations().getProductVersion();
         content = content.replaceAll(PRODUCT_VERSION_TEMPLATE, productVersion);
+
+        if (exportType != null && exportType.equals(EXPORT_TYPE_KUBERNETES)) {
+            content = content.replaceAll(APPS_BLOCK_TEMPLATE, "");
+        } else {
+            content = content.replaceAll(APPS_BLOCK_TEMPLATE, APPS_BLOCK_VALUE);
+        }
+
         if (jarsAdded) {
             content = content.replaceAll(JARS_BLOCK_TEMPLATE, JARS_BLOCK_VALUE);
         } else {
@@ -445,6 +455,11 @@ public class ExportUtils {
                             SIDDHI_PROCESS_DEFAULT_NAME
                     );
                 }
+            } else {
+                content = content.replaceAll(
+                        SIDDHI_PROCESS_NAME_TEMPLATE,
+                        SIDDHI_PROCESS_DEFAULT_NAME
+                );
             }
         }
         return content.getBytes(StandardCharsets.UTF_8);

--- a/tooling/features/io.siddhi.distribution.editor.core.feature/src/main/resources/docker-export/Dockerfile
+++ b/tooling/features/io.siddhi.distribution.editor.core.feature/src/main/resources/docker-export/Dockerfile
@@ -30,7 +30,7 @@ ARG CONFIG_FILE=./configurations.yaml
 ARG CONFIG_FILE_PATH=${HOME}/configurations.yaml
 
 # copy bundles & jars to the siddhi-runner distribution
-COPY --chown=siddhi_user:siddhi_io ${HOST_APPS_DIR}/ ${APPS}
+{{APPS_BLOCK}}
 {{JARS_BLOCK}}
 {{BUNDLES_BLOCK}}
 {{CONFIGURATION_BLOCK}}


### PR DESCRIPTION
## Purpose
Resolve https://github.com/siddhi-io/distribution/issues/420 https://github.com/siddhi-io/distribution/issues/421 

## Goals
- Remove unwanted Siddhi app copying
- Set default name for SiddhiProcess YAML

## Approach
- When `exportType=kubernetes` remove Siddhi app copy entry from Dockerfile
- If the user given Kubernetes config is null, set a default name for the SiddhiProcess YAML

## Documentation

**Kubernetes Export**
- Conditionally copy the Siddhi apps according to the export type
- Set up default name for all SiddhiProcess YAMLs when the user did not specify SiddhiProcess name

## Related PRs
https://github.com/siddhi-io/distribution/pull/335

## Test environment
Java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)