### PR TITLE
[Tooling] Set optional close all console tabs only in the tour guide

### DIFF
--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sink-form.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sink-form.js
@@ -450,6 +450,9 @@ define(['log', 'jquery', 'lodash', 'mapAnnotation', 'payloadOrAttribute', 'jsonV
                         self.configurationData.setIsDesignViewContentChanged(true);
                         // close the form window
                         self.consoleListManager.removeFormConsole(formConsole);
+                        if (self.application.browserStorage.get("isWidgetFromTourGuid")) {
+                            self.consoleListManager.removeAllConsoles();
+                        }
                     }
                 });
 

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sink-form.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/form-builder/forms/sink-form.js
@@ -450,7 +450,7 @@ define(['log', 'jquery', 'lodash', 'mapAnnotation', 'payloadOrAttribute', 'jsonV
                         self.configurationData.setIsDesignViewContentChanged(true);
                         // close the form window
                         self.consoleListManager.removeFormConsole(formConsole);
-                        if (self.application.browserStorage.get("isWidgetFromTourGuid")) {
+                        if (self.application.browserStorage.get("isWidgetFromTourGuide")) {
                             self.consoleListManager.removeAllConsoles();
                         }
                     }

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/form-builder/forms/stream-form.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/form-builder/forms/stream-form.js
@@ -285,7 +285,7 @@ define(['require', 'log', 'jquery', 'lodash', 'attribute', 'jsonValidator', 'con
                     self.configurationData.setIsDesignViewContentChanged(true);
                     // close the form window
                     self.consoleListManager.removeFormConsole(formConsole);
-                    if (self.application.browserStorage.get("isWidgetFromTourGuid")) {
+                    if (self.application.browserStorage.get("isWidgetFromTourGuide")) {
                         self.consoleListManager.removeAllConsoles();
                     }
                 }

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/form-builder/forms/stream-form.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/form-builder/forms/stream-form.js
@@ -285,6 +285,9 @@ define(['require', 'log', 'jquery', 'lodash', 'attribute', 'jsonValidator', 'con
                     self.configurationData.setIsDesignViewContentChanged(true);
                     // close the form window
                     self.consoleListManager.removeFormConsole(formConsole);
+                    if (self.application.browserStorage.get("isWidgetFromTourGuid")) {
+                        self.consoleListManager.removeAllConsoles();
+                    }
                 }
             });
 

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
@@ -425,6 +425,9 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryWindowOrFunct
 
                         // close the form window
                         self.consoleListManager.removeFormConsole(formConsole);
+                        if (self.application.browserStorage.get("isWidgetFromTourGuid")) {
+                            self.consoleListManager.removeAllConsoles();
+                        }
                     }
                 });
 

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/design-view/form-builder/forms/window-filter-projection-query-form.js
@@ -425,7 +425,7 @@ define(['require', 'log', 'jquery', 'lodash', 'querySelect', 'queryWindowOrFunct
 
                         // close the form window
                         self.consoleListManager.removeFormConsole(formConsole);
-                        if (self.application.browserStorage.get("isWidgetFromTourGuid")) {
+                        if (self.application.browserStorage.get("isWidgetFromTourGuide")) {
                             self.consoleListManager.removeAllConsoles();
                         }
                     }

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/guide/guide.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/guide/guide.js
@@ -43,7 +43,7 @@ define(['jquery', 'lodash', 'log', 'enjoyhint', 'designViewUtils', 'workspace', 
             //Script array for the complete guide
             this.completeGuide = [
                 {
-                    'click #newButton': '<b>Welcome to WSO2 Siddhi Editor!</b> Click <b class="lime-text">New</b> to get started.',
+                    'click #newButton': '<b>Welcome to Siddhi Editor!</b> Click <b class="lime-text">New</b> to get started.',
                     'showNext' : false
                 },
                 {
@@ -158,6 +158,7 @@ define(['jquery', 'lodash', 'log', 'enjoyhint', 'designViewUtils', 'workspace', 
                         $('#partition').removeClass('partition-drag');
                         $('#stream').addClass('stream-drag');
                         currentStep = instance.getCurrentStep();
+                        browserStorage.put("isWidgetFromTourGuid", true);
                         setTimeout(function () {
                             var interval = null;
                             interval = window.setInterval(function () {
@@ -483,6 +484,7 @@ define(['jquery', 'lodash', 'log', 'enjoyhint', 'designViewUtils', 'workspace', 
                                 clearInterval(interval);
                             }
                         }, 1000)
+                        browserStorage.put("isWidgetFromTourGuid", false);
                     }
                 },
                 {

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/guide/guide.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/guide/guide.js
@@ -158,7 +158,7 @@ define(['jquery', 'lodash', 'log', 'enjoyhint', 'designViewUtils', 'workspace', 
                         $('#partition').removeClass('partition-drag');
                         $('#stream').addClass('stream-drag');
                         currentStep = instance.getCurrentStep();
-                        browserStorage.put("isWidgetFromTourGuid", true);
+                        browserStorage.put("isWidgetFromTourGuide", true);
                         setTimeout(function () {
                             var interval = null;
                             interval = window.setInterval(function () {
@@ -484,7 +484,7 @@ define(['jquery', 'lodash', 'log', 'enjoyhint', 'designViewUtils', 'workspace', 
                                 clearInterval(interval);
                             }
                         }, 1000)
-                        browserStorage.put("isWidgetFromTourGuid", false);
+                        browserStorage.put("isWidgetFromTourGuide", false);
                     }
                 },
                 {


### PR DESCRIPTION
## Purpose
To resolve the failure to connect streams into projection widget in the tour guide.  

## Goals
Set optional close all console tabs only in the tour guide.

## Approach
In the process of tour guide, design view does not have enough space to hold all widgets actively. To gain more space we need to close the console. But console does not close after configuring a widget. Also, we cannot close it by default because it will cause to unexpected closing of the console when the user uses the design view without a tour guide.

As a solution, we set a flag called `isWidgetFromTourGuid` in the browser storage. We set that flag when we are going through the tour guide process. If that flag is set we close all the console tabs in widget level. Here we change those only for widgets used in the guide.

## Test environment
Java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)
Chrome browser
