### PR TITLE
Add validations to the /export docker config step

### DIFF
--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/commons/js/dialog/export-dialog.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/commons/js/dialog/export-dialog.js
@@ -69,7 +69,7 @@ define(['require', 'jquery', 'log', 'backbone', 'smart_wizard', 'siddhiAppSelect
                     this._exportUrl = options.config.baseUrl + "/export?exportType=" + this._exportType;
                     this._btnExportForm =  $('' +
                         '<form id="submit-form" method="post" enctype="application/x-www-form-urlencoded" target="export-download" >' +
-                        '<button  type="button" class="btn btn-primary hidden" id="export-btn" data-dismiss="modal" >Export</button>' +
+                        '<button type="button" class="btn btn-primary hidden" id="export-btn" >Export</button>' +
                         '</form>');
 
                 },
@@ -141,6 +141,8 @@ define(['require', 'jquery', 'log', 'backbone', 'smart_wizard', 'siddhiAppSelect
                                 getTemplatedKeyValues();
                                 return self._fill_template_value_dialog.
                                 validateTemplatedValues(self._payload.templatedVariables)
+                            } else if (stepNumber === 5) {
+                                return self._dockerConfigModel.validateDockerConfig();
                             }
                         }
                     });
@@ -244,6 +246,9 @@ define(['require', 'jquery', 'log', 'backbone', 'smart_wizard', 'siddhiAppSelect
                     var requestType = "downloadOnly"
 
                     if (this._exportType == "docker") {
+                        if (!this._dockerConfigModel.validateDockerConfig()) {
+                           return;
+                        }
                         if (this._payload.dockerConfiguration.pushDocker && this._payload.dockerConfiguration.downloadDocker) {
                             requestType = "downloadAndBuild";
                         } else if (this._payload.dockerConfiguration.pushDocker) {
@@ -271,6 +276,7 @@ define(['require', 'jquery', 'log', 'backbone', 'smart_wizard', 'siddhiAppSelect
                                     }
                                 }
                             });
+                            this._exportContainer.modal('hide');
                             return;
                         } else {
                             requestType = "downloadOnly";
@@ -285,6 +291,7 @@ define(['require', 'jquery', 'log', 'backbone', 'smart_wizard', 'siddhiAppSelect
                     exportUrl = exportUrl + "&requestType=" + requestType;
                     this._btnExportForm = this._btnExportForm.attr('action', exportUrl)
                     this._btnExportForm.submit();
+                    this._exportContainer.modal('hide');
                 },
 
                 clear: function () {

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/commons/js/dialog/export-dialog.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/commons/js/dialog/export-dialog.js
@@ -239,9 +239,7 @@ define(['require', 'jquery', 'log', 'backbone', 'smart_wizard', 'siddhiAppSelect
 
                     var payloadInputField = $('<input id="payload" name="payload" type="text" style="display: none;"/>')
                         .attr('value', JSON.stringify(this._payload));
-                    this._btnExportForm.append(payloadInputField);
 
-                    $(document.body).append(this._btnExportForm);
                     var exportUrl = this._exportUrl
                     var requestType = "downloadOnly"
 
@@ -252,6 +250,8 @@ define(['require', 'jquery', 'log', 'backbone', 'smart_wizard', 'siddhiAppSelect
                         if (this._payload.dockerConfiguration.pushDocker && this._payload.dockerConfiguration.downloadDocker) {
                             requestType = "downloadAndBuild";
                         } else if (this._payload.dockerConfiguration.pushDocker) {
+                            this._btnExportForm.append(payloadInputField);
+                            $(document.body).append(this._btnExportForm);
                             requestType = "buildOnly";
                             exportUrl = exportUrl + "&requestType=" + requestType;
                             $.ajax({
@@ -288,6 +288,8 @@ define(['require', 'jquery', 'log', 'backbone', 'smart_wizard', 'siddhiAppSelect
                             requestType = "downloadOnly";
                         }
                     }
+                    this._btnExportForm.append(payloadInputField);
+                    $(document.body).append(this._btnExportForm);
                     exportUrl = exportUrl + "&requestType=" + requestType;
                     this._btnExportForm = this._btnExportForm.attr('action', exportUrl)
                     this._btnExportForm.submit();

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/index.html
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/index.html
@@ -2531,23 +2531,26 @@
                         </div>
                         <div id="step-6" class="export-selector">
                             <div class='docker-config-container' id='docker-config-container-id'>
+                                <div id='missing-docker-config-error-message' class='step-description openDockerWizardError-container' hidden>
+                                    Required to fill Docker Configurations
+                                </div>
                                 <input class="docker-checkbox" type="checkbox" name="download-docker-artifacts" id="download-docker-artifacts" value="download"><label class="label-description">Download artifacts</label><br>
                                 <input class="docker-checkbox" type="checkbox" name="push-docker-image" id="docker-push-checkbox" value="push"><label class="label-description">Push to docker registry</label><br>
                                 <div class="docker-details-form" id="docker-details" hidden>
                                     <div class="docker-details-row">
-                                        <label class="clearfix">Docker Image Tag:</label>
+                                        <label class="clearfix">* Docker Image Tag:</label>
                                         <input class="file-dialog-form-control" type="text"  id="docker-img-name-input-field" placeholder="<DOCKER_REGISTRY_NAME>/<IMAGE_NAME>:<IMAGE_VERSION>">
                                     </div>
                                     <div class="docker-details-row">
-                                        <label class="clearfix">Docker Username:</label>
+                                        <label class="clearfix">* Docker Username:</label>
                                         <input class="file-dialog-form-control" type="text" name="username" id="userName">
                                     </div>
                                     <div class="docker-details-row">
-                                        <label class="clearfix">Docker Password:</label>
+                                        <label class="clearfix">* Docker Password:</label>
                                         <input class="file-dialog-form-control" type="password" name="password" id="password">
                                     </div>
                                     <div class="docker-details-row">
-                                        <label class="clearfix">Email:</label>
+                                        <label class="clearfix">* Email:</label>
                                         <input class="file-dialog-form-control" type="text" name="email" id="email">
                                     </div>
                                     <br/>

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/export-deployment-artifacts/docker-config-dialog.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/export-deployment-artifacts/docker-config-dialog.js
@@ -20,6 +20,7 @@ define(['require', 'lodash', 'jquery'],
     function (require, _, $) {
 
         var DockerConfigDialog = function (options) {
+            this.missingDockerConfigErrorMessage = options.templateHeader.find("#missing-docker-config-error-message");
             this.container = options.templateHeader;
             this.payload = options.payload;
             this.exportType = options.exportType;
@@ -45,6 +46,28 @@ define(['require', 'lodash', 'jquery'],
                     self.dockerDetailsForm.hide();
                 }
             });
+
+            self.container.find("#docker-push-checkbox").change(function() {
+                var pushDocker = self.container.find("#docker-push-checkbox").is(":checked");
+                var missingDockerConfigErrorMessage = self.container.find("#missing-docker-config-error-message");
+                if (!pushDocker) {
+                    missingDockerConfigErrorMessage.hide();
+                }
+            });
+
+            self.container.find("#docker-details").on('input', function() {
+                var imageName = self.container.find("#docker-img-name-input-field").val();
+                var userName = self.container.find("#userName").val();
+                var password = self.container.find("#password").val();
+                var email = self.container.find("#email").val();
+                var pushDocker = self.container.find("#docker-push-checkbox").is(":checked");
+                var missingDockerConfigErrorMessage = self.container.find("#missing-docker-config-error-message");
+                if (pushDocker) {
+                    if (imageName != "" && userName != "" && password != "" && email != "") {
+                        missingDockerConfigErrorMessage.hide();
+                    }
+                }
+            });
         };
 
         DockerConfigDialog.prototype.getDockerConfigs = function () {
@@ -57,6 +80,26 @@ define(['require', 'lodash', 'jquery'],
             templateKeyValue["downloadDocker"] = self.container.find("#download-docker-artifacts").is(":checked");
             templateKeyValue["pushDocker"] = self.container.find("#docker-push-checkbox").is(":checked");
             return templateKeyValue;
+        };
+
+        DockerConfigDialog.prototype.validateDockerConfig = function () {
+            var self = this;
+            var imageName = self.container.find("#docker-img-name-input-field").val();
+            var userName = self.container.find("#userName").val();
+            var password = self.container.find("#password").val();
+            var email = self.container.find("#email").val();
+            var pushDocker = self.container.find("#docker-push-checkbox").is(":checked");
+            if (pushDocker) {
+                if (imageName == "" || userName == "" || password == "" || email == "" ||
+                    imageName == null || userName == null || password == null || email == null
+                ) {
+                    this.missingDockerConfigErrorMessage.css('opacity', '1.0');
+                    this.missingDockerConfigErrorMessage.css('background-color', '#d9534f !important');
+                    this.missingDockerConfigErrorMessage.show();
+                    return false;
+                }
+            }
+            return true;
         };
 
         return DockerConfigDialog;


### PR DESCRIPTION
## Purpose
$subject.
Minor fix to https://github.com/siddhi-io/distribution/issues/377

## Goals
To handle docker config validation.

## Approach
Add jquery validations.

## Related PRs
https://github.com/siddhi-io/distribution/pull/329

## Test environment
Java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)
Google Chrome version 77.0.3865.90 (Official Build) (64-bit)