### PR TITLE
Add relative path support for -Dapps

### DIFF
--- a/resources/carbon-home/bin/runner.bat
+++ b/resources/carbon-home/bin/runner.bat
@@ -46,6 +46,7 @@ rem %~sdp0 is expanded pathname of the current script under NT with spaces in th
 set CARBON_HOME=%~sdp0..
 echo "%CARBON_HOME%\bin\version.txt"
 SET curDrive=%cd:~0,1%
+SET currentDirectory=%cd%
 SET wsasDrive=%CARBON_HOME:~0,1%
 if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
 
@@ -64,7 +65,7 @@ echo %CARBON_HOME%
 goto end
 
 :startServer
-%CARBON_HOME%\wso2\runner\bin\carbon.bat %*
+%CARBON_HOME%\wso2\runner\bin\carbon.bat -DcurrentDirectory=%currentDirectory% %*
 
 :end
 goto endlocal

--- a/resources/carbon-home/bin/runner.sh
+++ b/resources/carbon-home/bin/runner.sh
@@ -55,6 +55,8 @@ PRGDIR=`dirname "$PRG"`
 
 [ -z "$RUNTIME_HOME" ] && RUNTIME_HOME=`cd "$PRGDIR/../wso2/runner" ; pwd`
 
+CURRENT_DIRECTORY=`pwd`
+
 # Installing jars
 java -cp "$CARBON_HOME/bin/tools/*" -Dwso2.carbon.tool="install-jars" org.wso2.carbon.tools.CarbonToolExecutor "$CARBON_HOME"
 
@@ -65,5 +67,5 @@ NAME=start-runner
 RUNNER_INIT_SCRIPT="$CARBON_HOME/wso2/runner/bin/carbon.sh"
 
 # If the daemon is not there, then exit.
-$RUNNER_INIT_SCRIPT $*
+$RUNNER_INIT_SCRIPT -DcurrentDirectory="$CURRENT_DIRECTORY" $*
 exit;

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/internal/ServiceComponent.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/internal/ServiceComponent.java
@@ -52,6 +52,8 @@ import org.wso2.carbon.kernel.CarbonRuntime;
 import org.wso2.carbon.kernel.config.model.CarbonConfiguration;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -166,6 +168,22 @@ public class ServiceComponent {
                 log.error("Error: Can't get target file to run. System property {} is not set.",
                         SiddhiAppProcessorConstants.SYSTEM_PROP_RUN_SIDDHI_APPS);
             } else {
+                // Change relative paths to absolute
+                Path siddhiAppsGivenPath = Paths.get(siddhiAppsReference);
+                if (!siddhiAppsGivenPath.isAbsolute()) {
+                    if (System.getProperty(
+                            SiddhiAppProcessorConstants.SYSTEM_PROP_CURRENT_DIRECTORY
+                    ) != null) {
+                        Path currentWorkingDirectory = Paths.get(
+                                System.getProperty(
+                                        SiddhiAppProcessorConstants.SYSTEM_PROP_CURRENT_DIRECTORY
+                                )
+                        ).toAbsolutePath();
+                        siddhiAppsReference = currentWorkingDirectory.resolve(
+                                siddhiAppsGivenPath.toString()
+                        ).normalize().toString();
+                    }
+                }
                 siddhiAppFileReference = new File(siddhiAppsReference);
 
                 if (!siddhiAppFileReference.exists()) {

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/internal/util/SiddhiAppProcessorConstants.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/internal/util/SiddhiAppProcessorConstants.java
@@ -27,6 +27,7 @@ public class SiddhiAppProcessorConstants {
     public static final String SIDDHI_APP_FILE_EXTENSION = ".siddhi";
     public static final String SIDDHI_APP_REST_PREFIX = "siddhi-apps";
     public static final String SYSTEM_PROP_RUN_SIDDHI_APPS = "apps";
+    public static final String SYSTEM_PROP_CURRENT_DIRECTORY = "currentDirectory";
     public static final String SIDDHI_APP_DEPLOYMENT_DIRECTORY = "deployment";
     public static final String SIDDHI_APP_STATUS_ACTIVE = "active";
     public static final String SIDDHI_APP_STATUS_INACTIVE = "inactive";


### PR DESCRIPTION
## Purpose
Resolve https://github.com/siddhi-io/distribution/issues/338

## Goal
$subject

## Approach
- Get the current working directory of the user using sh/bat file as a system parameter.
- Check the -Dapps directory is relative or not.
- If it is a relative path, then change it to an absolute one and pass it.

## Test environment
Java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)
Mac OS High Sierra 
Windows 10
 