### PR TITLE
Escape error messages for html characters

### DIFF
--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/source-editor/editor.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/js/source-editor/editor.js
@@ -19,8 +19,9 @@
  * This will set the options of ACE editor, attach client side parser and attach SiddhiCompletion Engine with the editor
  */
 define(["ace/ace", "jquery", "./constants", "./utils", "./completion-engine", "./token-tooltip",
-        "ace/ext/language_tools", "./debug-rest-client", "log", 'ace/range'],
-    function (ace, $, constants, utils, CompletionEngine, aceTokenTooltip, aceExtLangTools, DebugRESTClient, log, AceRange) {
+        "ace/ext/language_tools", "./debug-rest-client", "log", 'ace/range', 'lodash'],
+    function (ace, $, constants, utils, CompletionEngine, aceTokenTooltip
+              , aceExtLangTools, DebugRESTClient, log, AceRange, _) {
 
         "use strict";   // JS strict mode
 
@@ -336,7 +337,7 @@ define(["ace/ace", "jquery", "./constants", "./utils", "./completion-engine", ".
                                 self.state.semanticErrorList = [({
                                     row: 0,
                                     // Change attribute "text" to "html" if html is sent from server
-                                    html: utils.wordWrap(response.message, 120),
+                                    html: utils.wordWrap(_.escape(response.message), 120),
                                     type: "error"
                                 })];
 
@@ -350,7 +351,7 @@ define(["ace/ace", "jquery", "./constants", "./utils", "./completion-engine", ".
                                 self.state.semanticErrorList = [({
                                     row: response.queryContextStartIndex[0] - 1,
                                     // Change attribute "text" to "html" if html is sent from server
-                                    html: utils.wordWrap(response.message, 120),
+                                    html: utils.wordWrap(_.escape(response.message), 120),
                                     type: "error"
                                 })];
 


### PR DESCRIPTION
## Purpose
$subject. This fixes the issue if the logs include '<', it was not properly displayed.
![Screenshot from 2019-10-03 21-32-35](https://user-images.githubusercontent.com/27669465/66144253-1c552a80-e626-11e9-8b12-e303a3d1bb00.png)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes