### PR TITLE
Fix on demand query not executing when it has new line

### DIFF
--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
@@ -298,8 +298,7 @@ public class EditorMicroservice implements Microservice {
         }
 
         try {
-            feign.Response response = storeQueryAPIHelper
-                    .executeStoreQuery(request.getProperty("LOCAL_ADDRESS").toString(), element.toString());
+            feign.Response response = storeQueryAPIHelper.executeStoreQuery(element.toString());
             String payload = response.body().toString();
             // If the response HTTP status code is OK, return the response.
             if (response.status() == 200) {

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/util/restclients/storequery/StoreQueryHTTPClient.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/util/restclients/storequery/StoreQueryHTTPClient.java
@@ -25,8 +25,7 @@ import feign.Response;
  */
 public class StoreQueryHTTPClient {
 
-    // host will include a backslash at the start
-    private static final String PROTOCOL = "http:/";
+    private static final String PROTOCOL = "http://";
 
     /**
      * Avoids Instantiation of the default constructor.

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/commons/js/dialog/query-store-rest-client.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/commons/js/dialog/query-store-rest-client.js
@@ -20,12 +20,19 @@ define(["jquery"], function (jQuery) {
     var self = {};
     self.siddhiStoreUrl = window.location.protocol + "//" + window.location.host + "/editor/query";
     self.retrieveStoresQuery = function (appName, query, successCallback, errorCallback) {
+        
+        var request = {
+          "appName" : appName,
+          "query" : query,
+          "details" : true
+        };
+
         jQuery.ajax({
             async: true,
             type: "POST",
             contentType: "application/json",
             url: self.siddhiStoreUrl,
-            data: "{\"appName\": \"" + appName + "\", \"query\": \"" + query + "\", \"details\": true }",
+            data: JSON.stringify(request),
             success: function (data) {
                 if (typeof successCallback === 'function') {
                     successCallback(data);


### PR DESCRIPTION
## Purpose
1. Fix $subject, Escape newline characters in ondemand query
2. Add optional config to override store Query API host and port as follows
```
storeRESTAPI:
  host: "0.0.0.0"
  port: "9390"

```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes