### PR TITLE
Add proper names to export zip file

### DIFF
--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
@@ -1182,11 +1182,10 @@ public class EditorMicroservice implements Microservice {
             ExportAppsRequest exportAppsRequest = new Gson().fromJson(payload, ExportAppsRequest.class);
             ExportUtils exportUtils = new ExportUtils(configProvider, exportAppsRequest, exportType);
             File zipFile = exportUtils.createZipFile();
-            String fileName = "siddhi-docker.zip";
+            String fileName = exportUtils.getZipFileName();
             boolean kubernetesEnabled = false;
             if (exportType != null) {
                 if (exportType.equals(EXPORT_TYPE_KUBERNETES)) {
-                    fileName = "siddhi-kubernetes.zip";
                     kubernetesEnabled = true;
                 }
             }

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/ExportUtils.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/ExportUtils.java
@@ -168,10 +168,11 @@ public class ExportUtils {
             zipFileName = "siddhi-kubernetes.zip";
             zipFileRoot = "siddhi-kubernetes/";
             if (exportAppsRequest.getKubernetesConfiguration() != null) {
-                if (exportAppsRequest.getKubernetesConfiguration() != null) {
-                    KubernetesConfig kubernetesConfig = getKubernetesConfigs(
-                            exportAppsRequest.getKubernetesConfiguration()
-                    );
+                KubernetesConfig kubernetesConfig = getKubernetesConfigs(
+                        exportAppsRequest.getKubernetesConfiguration()
+                );
+
+                if (kubernetesConfig != null && kubernetesConfig.getSiddhiProcessName() != null) {
                     zipFileName = kubernetesConfig.getSiddhiProcessName().toLowerCase().trim()
                             + ".zip";
                     zipFileRoot = kubernetesConfig.getSiddhiProcessName().toLowerCase().trim()


### PR DESCRIPTION
## Purpose
Previously Siddhi tooling returns zip files with static names for each K8s and Docker deployments. That makes users confused sometimes even after exporting multiple zip files.

## Goals
$subject

## Approach
Change naming conventions like below.
- Docker push + build -> zip file name is image name replacing ": and /" with "-"
- Kubernetes ->  zip file name is SiddhiProcess object name

## Related PRs
https://github.com/siddhi-io/distribution/pull/329

## Test environment
Java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)
Google Chrome Version 77.0.3865.90 (Official Build) (64-bit)
 