### PR TITLE
Support partial app creation for in-memory bridged apps

### DIFF
--- a/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/topology/SiddhiTopologyCreatorImpl.java
+++ b/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/topology/SiddhiTopologyCreatorImpl.java
@@ -180,24 +180,23 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
                 String streamId = entry.getKey();
                 StreamDefinition streamDefinition = siddhiApp.getStreamDefinitionMap().get(streamId);
 
-                if (outputStreamDataHolder.getEventHolderType().equals(EventHolder.STREAM)) {
-                    if (outputStreamDataHolder.isUserGiven() && streamDefinition != null) {
-                        for (Annotation annotation : streamDefinition.getAnnotations()) {
-                            if (annotation.getName().equalsIgnoreCase(SiddhiTopologyCreatorConstants.SINK_IDENTIFIER
-                                    .replace("@", ""))) {
-                                if (annotation.getElement("type").equalsIgnoreCase(INMEMORY)) {
-                                    String runtimeStreamDefinition = removeMetaInfoStream(streamId,
-                                            outputStreamDataHolder.getStreamDefinition(),
-                                            SiddhiTopologyCreatorConstants.SINK_IDENTIFIER);
+                if (outputStreamDataHolder.getEventHolderType().equals(EventHolder.STREAM) &&
+                        outputStreamDataHolder.isUserGiven() && streamDefinition != null) {
+                    for (Annotation annotation : streamDefinition.getAnnotations()) {
+                        if (annotation.getName().equalsIgnoreCase(SiddhiTopologyCreatorConstants.SINK_IDENTIFIER
+                                .replace("@", ""))) {
+                            if (annotation.getElement("type").equalsIgnoreCase(INMEMORY)) {
+                                String runtimeStreamDefinition = removeMetaInfoStream(streamId,
+                                        outputStreamDataHolder.getStreamDefinition(),
+                                        SiddhiTopologyCreatorConstants.SINK_IDENTIFIER);
 
-                                    String outputStreamDefinition = "${" + streamId + "} " + runtimeStreamDefinition;
-                                    OutputStreamDataHolder streamDataHolder = new OutputStreamDataHolder(streamId,
-                                            outputStreamDefinition, EventHolder.STREAM, false);
-                                    streamDataHolder.addPublishingStrategy(
-                                            new PublishingStrategyDataHolder(TransportStrategy.ALL,
-                                                    DEFAULT_PARALLEL));
-                                    entry.setValue(streamDataHolder);
-                                }
+                                String outputStreamDefinition = "${" + streamId + "} " + runtimeStreamDefinition;
+                                OutputStreamDataHolder streamDataHolder = new OutputStreamDataHolder(streamId,
+                                        outputStreamDefinition, EventHolder.STREAM, false);
+                                streamDataHolder.addPublishingStrategy(
+                                        new PublishingStrategyDataHolder(TransportStrategy.ALL,
+                                                DEFAULT_PARALLEL));
+                                entry.setValue(streamDataHolder);
                             }
                         }
                     }
@@ -207,19 +206,18 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
                 InputStreamDataHolder inputStreamDataHolder = entry.getValue();
                 String streamId = entry.getKey();
                 StreamDefinition streamDefinition = siddhiApp.getStreamDefinitionMap().get(streamId);
-                if (inputStreamDataHolder.getEventHolderType().equals(EventHolder.STREAM)) {
-                    if (inputStreamDataHolder.isUserGiven() && streamDefinition != null) {
-                        for (Annotation annotation : streamDefinition.getAnnotations()) {
-                            if (annotation.getName().equalsIgnoreCase(SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER
-                                    .replace("@", ""))) {
-                                if (annotation.getElement("type").equalsIgnoreCase(INMEMORY)) {
-                                    String runtimeStreamDefinition = removeMetaInfoStream(streamId,
-                                            inputStreamDataHolder.getStreamDefinition(),
-                                            SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER);
-                                    String inputStreamDefinition = "${" + streamId + "} " + runtimeStreamDefinition;
-                                    inputStreamDataHolder.setStreamDefinition(inputStreamDefinition);
-                                    inputStreamDataHolder.setUserGiven(false);
-                                }
+                if (inputStreamDataHolder.getEventHolderType().equals(EventHolder.STREAM) &&
+                        inputStreamDataHolder.isUserGiven() && streamDefinition != null) {
+                    for (Annotation annotation : streamDefinition.getAnnotations()) {
+                        if (annotation.getName().equalsIgnoreCase(SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER
+                                .replace("@", ""))) {
+                            if (annotation.getElement("type").equalsIgnoreCase(INMEMORY)) {
+                                String runtimeStreamDefinition = removeMetaInfoStream(streamId,
+                                        inputStreamDataHolder.getStreamDefinition(),
+                                        SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER);
+                                String inputStreamDefinition = "${" + streamId + "} " + runtimeStreamDefinition;
+                                inputStreamDataHolder.setStreamDefinition(inputStreamDefinition);
+                                inputStreamDataHolder.setUserGiven(false);
                             }
                         }
                     }

--- a/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/topology/SiddhiTopologyCreatorImpl.java
+++ b/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/topology/SiddhiTopologyCreatorImpl.java
@@ -60,6 +60,9 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.UUID;
 
+import static io.siddhi.parser.core.util.SiddhiTopologyCreatorConstants.DEFAULT_PARALLEL;
+import static io.siddhi.parser.core.util.SiddhiTopologyCreatorConstants.INMEMORY;
+
 /**
  * Consumes a Siddhi App and produce a {@link SiddhiTopology} based on distributed annotations.
  */
@@ -104,6 +107,7 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
 
         checkUserGivenSourceDistribution();
         assignPublishingStrategyOutputStream();
+        checkForInmemoryBridges();
         cleanInnerGroupStreams(siddhiTopologyDataHolder.getSiddhiQueryGroupMap().values());
         if (log.isDebugEnabled()) {
             log.debug("Topology was created with " + siddhiTopologyDataHolder.getSiddhiQueryGroupMap().values().size
@@ -164,6 +168,64 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
             }
         }
         return false;
+    }
+
+    private void checkForInmemoryBridges() {
+        List<SiddhiQueryGroup> siddhiQueryGroupsList =
+                new ArrayList<>(siddhiTopologyDataHolder.getSiddhiQueryGroupMap().values());
+
+        for (SiddhiQueryGroup siddhiQueryGroup : siddhiQueryGroupsList) {
+            for (Entry<String, OutputStreamDataHolder> entry : siddhiQueryGroup.getOutputStreams().entrySet()) {
+                OutputStreamDataHolder outputStreamDataHolder = entry.getValue();
+                String streamId = entry.getKey();
+                StreamDefinition streamDefinition = siddhiApp.getStreamDefinitionMap().get(streamId);
+
+                if (outputStreamDataHolder.getEventHolderType().equals(EventHolder.STREAM)) {
+                    if (outputStreamDataHolder.isUserGiven() && streamDefinition != null) {
+                        for (Annotation annotation : streamDefinition.getAnnotations()) {
+                            if (annotation.getName().equalsIgnoreCase(SiddhiTopologyCreatorConstants.SINK_IDENTIFIER
+                                    .replace("@", ""))) {
+                                if (annotation.getElement("type").equalsIgnoreCase(INMEMORY)) {
+                                    String runtimeStreamDefinition = removeMetaInfoStream(streamId,
+                                            outputStreamDataHolder.getStreamDefinition(),
+                                            SiddhiTopologyCreatorConstants.SINK_IDENTIFIER);
+
+                                    String outputStreamDefinition = "${" + streamId + "} " + runtimeStreamDefinition;
+                                    OutputStreamDataHolder streamDataHolder = new OutputStreamDataHolder(streamId,
+                                            outputStreamDefinition, EventHolder.STREAM, false);
+                                    streamDataHolder.addPublishingStrategy(
+                                            new PublishingStrategyDataHolder(TransportStrategy.ALL,
+                                                    DEFAULT_PARALLEL));
+                                    entry.setValue(streamDataHolder);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            for (Entry<String, InputStreamDataHolder> entry : siddhiQueryGroup.getInputStreams().entrySet()) {
+                InputStreamDataHolder inputStreamDataHolder = entry.getValue();
+                String streamId = entry.getKey();
+                StreamDefinition streamDefinition = siddhiApp.getStreamDefinitionMap().get(streamId);
+                if (inputStreamDataHolder.getEventHolderType().equals(EventHolder.STREAM)) {
+                    if (inputStreamDataHolder.isUserGiven() && streamDefinition != null) {
+                        for (Annotation annotation : streamDefinition.getAnnotations()) {
+                            if (annotation.getName().equalsIgnoreCase(SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER
+                                    .replace("@", ""))) {
+                                if (annotation.getElement("type").equalsIgnoreCase(INMEMORY)) {
+                                    String runtimeStreamDefinition = removeMetaInfoStream(streamId,
+                                            inputStreamDataHolder.getStreamDefinition(),
+                                            SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER);
+                                    String inputStreamDefinition = "${" + streamId + "} " + runtimeStreamDefinition;
+                                    inputStreamDataHolder.setStreamDefinition(inputStreamDefinition);
+                                    inputStreamDataHolder.setUserGiven(false);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -408,6 +470,7 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
 
     private void checkUserGivenSourceDistribution() {
         boolean passthroughQueriesAvailable = false;
+        boolean isInmemoryBridged = false;
         List<SiddhiQueryGroup> siddhiQueryGroupsList =
                 new ArrayList<>(siddhiTopologyDataHolder.getSiddhiQueryGroupMap().values());
 
@@ -432,13 +495,15 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
                                 .replace("@", ""))) {
                             if (annotation.getElement("type").equalsIgnoreCase(DEFAULT_MESSAGING_SYSTEM)) {
                                 siddhiQueryGroup.setMessagingSourceAvailable(true);
+                            } else if (annotation.getElement("type").equalsIgnoreCase(INMEMORY)) {
+                                isInmemoryBridged = true;
                             } else {
                                 nonMessagingSources++;
                             }
                         }
                     }
-                    if ((!siddhiQueryGroup.isMessagingSourceAvailable() || nonMessagingSources > 0)
-                            && isStatefulApp()) {
+                    if (((!siddhiQueryGroup.isMessagingSourceAvailable() && !isInmemoryBridged)
+                            || nonMessagingSources > 0) && isStatefulApp()) {
                         passthroughQueriesAvailable = true;
                         generatePassthroughQueryList(inputStreamDataHolder, runtimeDefinition);
                         inputStreamDataHolder.setStreamDefinition(runtimeDefinition);

--- a/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/util/SiddhiTopologyCreatorConstants.java
+++ b/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/util/SiddhiTopologyCreatorConstants.java
@@ -59,7 +59,7 @@ public class SiddhiTopologyCreatorConstants {
 
     public static final String AGGREGATION = "aggregation";
 
-    public static final String INMEMORY = "in-memory";
+    public static final String INMEMORY = "inmemory";
 
     public static final String EXECUTION_ELEMENT = "Query/Partition";
 }

--- a/runner/components/io.siddhi.parser/src/test/java/io/siddhi/parser/NatsAppCreatorTestCase.java
+++ b/runner/components/io.siddhi.parser/src/test/java/io/siddhi/parser/NatsAppCreatorTestCase.java
@@ -115,4 +115,83 @@ public class NatsAppCreatorTestCase {
 
         Assert.assertEquals(queryGroupList.size(), 2);
     }
+
+    /** Test partial app creation for a user given app with an in-memory sink.
+     */
+    @Test
+    public void testInmemoryBridgedAppParsing1() {
+        String siddhiApp = "@App:name('InmemoryTransportTestApp') " +
+                "@Source(type = 'http', receiver.url = 'http://0.0.0.0:8080/stockStream', " +
+                "basic.auth.enabled = 'false', @map(type = 'json'))\n"
+                + "Define stream stockStream(symbol string, price float, quantity int, tier string);\n"
+                + "@sink(type='inMemory', topic='takingOverTopic', @map(type='passThrough'))\n"
+                + "Define stream takingOverStream(symbol string, overtakingSymbol string, avgPrice double);\n"
+                + "@info(name = 'query1')\n"
+                + "From stockStream[price > 100]\n"
+                + "Select *\n"
+                + "Insert into filteredStockStream;\n"
+                + "@info(name = 'query2')"
+                + "Partition with (symbol of filteredStockStream)\n"
+                + "begin\n"
+                + "From filteredStockStream#window.lengthBatch(2)\n"
+                + "Select symbol, tier as overtakingSymbol,avg(price) as avgPrice  \n"
+                + "Insert into takingOverStream;\n"
+                + "end;\n"
+                + "@info(name ='query3')\n"
+                + "from filteredStockStream [price >250 and price <350]\n"
+                + "Select \"XYZ\" as symbol, tier as overtakingSymbol ,avg(price) as avgPrice  \n"
+                + "Insert into takingOverStream;\n";
+        SiddhiTopologyCreatorImpl siddhiTopologyCreator = new SiddhiTopologyCreatorImpl();
+        SiddhiTopology topology = siddhiTopologyCreator.createTopology(siddhiApp);
+        SiddhiAppCreator appCreator = new NatsSiddhiAppCreator();
+        List<DeployableSiddhiQueryGroup> queryGroupList = appCreator.createApps(topology, messagingSystem);
+
+        Assert.assertEquals(queryGroupList.size(), 2);
+        Assert.assertTrue(queryGroupList.get(0).isReceiverQueryGroup());
+        String processApp = queryGroupList.get(1).getSiddhiQueries().get(0).getApp();
+        Assert.assertFalse(processApp.contains("@sink(type='inMemory', topic='takingOverTopic', " +
+                "@map(type='passThrough'))"));
+        Assert.assertTrue(processApp.contains("@sink(type='nats',cluster.id='test-cluster'," +
+                "destination = 'InmemoryTransportTestApp_takingOverStream'"));
+    }
+
+    /** Test partial app creation for a user given app with in-memory sink & source.
+     */
+    @Test
+    public void testInmemoryBridgedAppParsing2() {
+        String siddhiApp = "@App:name('InmemoryTransportTestApp') " +
+                "@source(type='inMemory', topic='stockStream', @map(type='passThrough'))\n"
+                + "Define stream stockStream(symbol string, price float, quantity int, tier string);\n"
+                + "@sink(type='inMemory', topic='takingOverTopic', @map(type='passThrough'))\n"
+                + "Define stream takingOverStream(symbol string, overtakingSymbol string, avgPrice double);\n"
+                + "@info(name = 'query1')\n"
+                + "From stockStream[price > 100]\n"
+                + "Select *\n"
+                + "Insert into filteredStockStream;\n"
+                + "@info(name = 'query2')"
+                + "Partition with (symbol of filteredStockStream)\n"
+                + "begin\n"
+                + "From filteredStockStream#window.lengthBatch(2)\n"
+                + "Select symbol, tier as overtakingSymbol,avg(price) as avgPrice  \n"
+                + "Insert into takingOverStream;\n"
+                + "end;\n"
+                + "@info(name ='query3')\n"
+                + "from filteredStockStream [price >250 and price <350]\n"
+                + "Select \"XYZ\" as symbol, tier as overtakingSymbol ,avg(price) as avgPrice  \n"
+                + "Insert into takingOverStream;\n";
+        SiddhiTopologyCreatorImpl siddhiTopologyCreator = new SiddhiTopologyCreatorImpl();
+        SiddhiTopology topology = siddhiTopologyCreator.createTopology(siddhiApp);
+        SiddhiAppCreator appCreator = new NatsSiddhiAppCreator();
+        List<DeployableSiddhiQueryGroup> queryGroupList = appCreator.createApps(topology, messagingSystem);
+
+        Assert.assertEquals(queryGroupList.size(), 1);
+        String app = queryGroupList.get(0).getSiddhiQueries().get(0).getApp();
+        Assert.assertFalse(app.contains("@source(type='inMemory', topic='stockStream', @map(type='passThrough'))"));
+        Assert.assertFalse(app.contains("@sink(type='inMemory', topic='takingOverTopic', " +
+                "@map(type='passThrough'))"));
+        Assert.assertTrue(app.contains("@source(type='nats',cluster.id='test-cluster'," +
+                "destination = 'InmemoryTransportTestApp_stockStream'"));
+        Assert.assertTrue(app.contains("@sink(type='nats',cluster.id='test-cluster'," +
+                "destination = 'InmemoryTransportTestApp_takingOverStream'"));
+    }
 }


### PR DESCRIPTION
## Purpose
> $subject

## Approach
> Replace in-memory source & sink with a messaging template at topology creation. Use the messaging system to create sources and sinks as needed at app creation. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
