### PR TITLE
Remove editor file system based hot deployment

### DIFF
--- a/tooling/components/io.siddhi.distribution.editor.core/pom.xml
+++ b/tooling/components/io.siddhi.distribution.editor.core/pom.xml
@@ -227,8 +227,7 @@
     <properties>
         <maven.findbugsplugin.version.exclude>findbugs-exclude.xml</maven.findbugsplugin.version.exclude>
         <carbon.component>
-            osgi.service; objectClass="org.wso2.msf4j.Microservice"; serviceCount="1",
-            osgi.service; objectClass="org.wso2.carbon.deployment.engine.Deployer";serviceCount="1"
+            osgi.service; objectClass="org.wso2.msf4j.Microservice"; serviceCount="1"
         </carbon.component>
     </properties>
 

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
@@ -631,6 +631,8 @@ public class EditorMicroservice implements Microservice {
             }
             byte[] base64Config = Base64.getDecoder().decode(config);
             byte[] base64ConfigName = Base64.getDecoder().decode(configName);
+            WorkspaceDeployer.deployConfigFile(new String(base64ConfigName, Charset.defaultCharset()),
+                    new String(base64Config, Charset.defaultCharset()));
             java.nio.file.Path filePath = SecurityUtil.resolvePath(
                     Paths.get(location).toAbsolutePath(),
                     Paths.get(Constants.DIRECTORY_WORKSPACE + System.getProperty(FILE_SEPARATOR) +
@@ -718,6 +720,7 @@ public class EditorMicroservice implements Microservice {
                 entity.addProperty(STATUS, SUCCESS);
                 entity.addProperty("path", Constants.DIRECTORY_WORKSPACE);
                 entity.addProperty("message", "Siddi App: " + siddhiAppName + " is deleted");
+                WorkspaceDeployer.unDeployConfigFile(siddhiAppName);
                 return Response.status(Response.Status.OK).entity(entity)
                         .type(MediaType.APPLICATION_JSON).build();
             } else {

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/WorkspaceDeployer.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/WorkspaceDeployer.java
@@ -18,131 +18,24 @@
 
 package io.siddhi.distribution.editor.core.internal;
 
-import io.siddhi.distribution.common.common.EventStreamService;
-import io.siddhi.distribution.editor.core.exception.SiddhiAppDeploymentException;
 import org.apache.commons.io.FilenameUtils;
-import org.osgi.framework.BundleContext;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.carbon.deployment.engine.Artifact;
-import org.wso2.carbon.deployment.engine.ArtifactType;
-import org.wso2.carbon.deployment.engine.Deployer;
 import org.wso2.carbon.deployment.engine.exception.CarbonDeploymentException;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.nio.charset.Charset;
 
 /**
  * WorkspaceDeployer is responsible for all editor workspace related deployment tasks.
  */
-@Component(
-        name = "workspace-artifact-deployer",
-        immediate = true,
-        service = Deployer.class
-)
-public class WorkspaceDeployer implements Deployer {
+public class WorkspaceDeployer {
 
-    private static final String WORKSPACE_DIRECTORY = "workspace";
     private static final Logger log = LoggerFactory.getLogger(WorkspaceDeployer.class);
-    private static final String FILE_EXTENSION = "siddhi";
-    private ArtifactType artifactType = new ArtifactType<>(FILE_EXTENSION);
-    private URL directoryLocation;
 
-    private static String getStringFromInputStream(InputStream is) throws SiddhiAppDeploymentException {
-
-        BufferedReader br = null;
-        StringBuilder sb = new StringBuilder();
-        String line;
-        try {
-            br = new BufferedReader(new InputStreamReader(is, Charset.forName("UTF-8")));
-            while ((line = br.readLine()) != null) {
-                sb.append(System.getProperty("line.separator")).append(line);
-            }
-        } catch (IOException e) {
-            throw new SiddhiAppDeploymentException("Exception when reading the Siddhi QL file", e);
-        } finally {
-            if (br != null) {
-                try {
-                    br.close();
-                } catch (IOException e) {
-                    throw new SiddhiAppDeploymentException("Exception when closing the Siddhi QL file stream", e);
-                }
-            }
-        }
-        return sb.toString();
+    static void deployConfigFile(String siddhiAppFileName, String siddhiApp) throws Exception {
+        EditorDataHolder.getDebugProcessorService().deploy(FilenameUtils.getBaseName(siddhiAppFileName), siddhiApp);
+        log.info("Siddhi App " + siddhiAppFileName + " successfully deployed.");
     }
 
-    private void deployConfigFile(File file) throws Exception {
-
-        if (!file.getName().startsWith(".")) {
-            InputStream inputStream = null;
-            try {
-                if (FilenameUtils.isExtension(file.getName(), FILE_EXTENSION)) {
-                    String siddhiAppName = FilenameUtils.getBaseName(file.getName());
-                    inputStream = new FileInputStream(file);
-                    String siddhiApp = getStringFromInputStream(inputStream);
-                    EditorDataHolder.getDebugProcessorService().deploy(siddhiAppName, siddhiApp);
-                    log.info("Siddhi App " + siddhiAppName + " successfully deployed.");
-                } else {
-                    log.error(("Error: File extension not supported for file name "
-                            + file.getName() + ". Supports only '"
-                            + FILE_EXTENSION + "'."));
-                }
-            } finally {
-                if (inputStream != null) {
-                    try {
-                        inputStream.close();
-                    } catch (IOException e) {
-                        throw new SiddhiAppDeploymentException("Error when closing the Siddhi QL filestream", e);
-                    }
-                }
-            }
-        }
-    }
-
-    @Activate
-    protected void activate(BundleContext bundleContext) {
-        // Nothing to do.
-    }
-
-    @Override
-    public void init() {
-
-        try {
-            directoryLocation = new URL("file:" + WORKSPACE_DIRECTORY);
-            log.info("Workspace artifact deployer initiated.");
-        } catch (MalformedURLException e) {
-            log.error("Error while initializing workspace artifact directoryLocation : "
-                    + WORKSPACE_DIRECTORY, e);
-        }
-    }
-
-    @Override
-    public Object deploy(Artifact artifact) throws CarbonDeploymentException {
-
-        try {
-            deployConfigFile(artifact.getFile());
-        } catch (Exception e) {
-            throw new CarbonDeploymentException(e.getMessage(), e);
-        }
-        return artifact.getFile().getName();
-    }
-
-    @Override
-    public void undeploy(Object key) throws CarbonDeploymentException {
-
+    static void unDeployConfigFile(String key) throws Exception {
         try {
             String siddhiAppName = FilenameUtils.getBaseName((String) key);
             if (EditorDataHolder.getSiddhiAppMap().containsKey(siddhiAppName)) {
@@ -150,50 +43,6 @@ public class WorkspaceDeployer implements Deployer {
             }
         } catch (Exception e) {
             throw new CarbonDeploymentException(e.getMessage(), e);
-        }
-    }
-
-    @Override
-    public Object update(Artifact artifact) throws CarbonDeploymentException {
-
-        try {
-            deployConfigFile(artifact.getFile());
-        } catch (Exception e) {
-            throw new CarbonDeploymentException(e.getMessage(), e);
-        }
-        return artifact.getName();
-    }
-
-    @Override
-    public URL getLocation() {
-
-        return directoryLocation;
-    }
-
-    @Override
-    public ArtifactType getArtifactType() {
-
-        return artifactType;
-    }
-
-    @Reference(
-            name = "event.stream.service",
-            service = EventStreamService.class,
-            cardinality = ReferenceCardinality.MANDATORY,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetEventStreamService"
-    )
-    protected void setEventStreamService(EventStreamService eventStreamService) {
-
-        if (log.isDebugEnabled()) {
-            log.info("@Reference(bind) EventStreamService");
-        }
-    }
-
-    protected void unsetEventStreamService(EventStreamService eventStreamService) {
-
-        if (log.isDebugEnabled()) {
-            log.info("@Reference(unbind) EventStreamService");
         }
     }
 }


### PR DESCRIPTION
## Purpose
> This PR removes the file based hot deployment capabilities in Siddhi tooling runtime. Now, if there are any changes made then it will get reflected in the in-memory state immediately and get saved as well. Due to this fix, users don't have to wait until default file system based hot deployment runs.
