### PR TITLE
[Distributed Deployment] Use user-given topic for inMemory bridges during parsing

### DIFF
--- a/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/appcreator/NatsSiddhiAppCreator.java
+++ b/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/appcreator/NatsSiddhiAppCreator.java
@@ -215,9 +215,12 @@ public class NatsSiddhiAppCreator extends AbstractSiddhiAppCreator {
                     updateQueryList(queryList, queryValuesMap);
 
                 } else if (subscriptionStrategy.getStrategy() == TransportStrategy.ALL) {
-
-                    sourceValuesMap.put(TOPIC_LIST, getTopicName(siddhiAppName,
-                            inputStream.getStreamName(), null));
+                    if (inputStream.getInMemoryTopic() != null) {
+                        sourceValuesMap.put(TOPIC_LIST, inputStream.getInMemoryTopic());
+                    } else {
+                        sourceValuesMap.put(TOPIC_LIST, getTopicName(siddhiAppName,
+                                inputStream.getStreamName(), null));
+                    }
                     for (SiddhiQuery aQueryList : queryList) {
                         String sourceString = getUpdatedQuery(DEFAULT_NATS_SOURCE_TEMPLATE, sourceValuesMap);
                         Map<String, String> queryValuesMap = new HashMap(1);

--- a/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/topology/InputStreamDataHolder.java
+++ b/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/topology/InputStreamDataHolder.java
@@ -31,6 +31,7 @@ public class InputStreamDataHolder {
     private boolean isUserGiven;
     private SubscriptionStrategyDataHolder subscriptionStrategy;
     private boolean isInnerGroupStream;
+    private String inMemoryTopic;
 
     public InputStreamDataHolder(String streamName, String streamDefinition, EventHolder eventHolderType,
                                  boolean isUserGiven, SubscriptionStrategyDataHolder subscriptionStrategy) {
@@ -80,5 +81,13 @@ public class InputStreamDataHolder {
 
     public boolean isUserGivenSource() {
         return streamDefinition.toLowerCase().contains(SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER);
+    }
+
+    public void setInMemoryTopic(String inMemoryTopic) {
+        this.inMemoryTopic = inMemoryTopic;
+    }
+
+    public String getInMemoryTopic() {
+        return inMemoryTopic;
     }
 }

--- a/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/topology/OutputStreamDataHolder.java
+++ b/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/topology/OutputStreamDataHolder.java
@@ -34,6 +34,7 @@ public class OutputStreamDataHolder {
     private boolean isUserGiven;
     private boolean isInnerGroupStream;
     private boolean isSinkBridgeAdded;
+    private String inmemoryTopicName;
 
     public OutputStreamDataHolder(String streamName, String streamDefinition, EventHolder eventHolderType,
                                   boolean isUserGiven) {
@@ -88,6 +89,14 @@ public class OutputStreamDataHolder {
 
     public void setSinkBridgeAdded(boolean sinkBridgeAdded) {
         isSinkBridgeAdded = sinkBridgeAdded;
+    }
+
+    public String getInmemoryTopicName() {
+        return inmemoryTopicName;
+    }
+
+    public void setInmemoryTopicName(String inmemoryTopicName) {
+        this.inmemoryTopicName = inmemoryTopicName;
     }
 }
 

--- a/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/topology/SiddhiTopologyCreatorImpl.java
+++ b/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/topology/SiddhiTopologyCreatorImpl.java
@@ -184,6 +184,7 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
                         if (annotation.getName().equalsIgnoreCase(SiddhiTopologyCreatorConstants.SINK_IDENTIFIER
                                 .replace("@", ""))) {
                             if (annotation.getElement("type").equalsIgnoreCase(INMEMORY)) {
+                                String topic = annotation.getElement("topic");
                                 String runtimeStreamDefinition = removeMetaInfoStream(streamId,
                                         outputStreamDataHolder.getStreamDefinition(),
                                         SiddhiTopologyCreatorConstants.SINK_IDENTIFIER, INMEMORY);
@@ -191,6 +192,7 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
                                 String outputStreamDefinition = "${" + streamId + "} " + runtimeStreamDefinition;
                                 OutputStreamDataHolder streamDataHolder = new OutputStreamDataHolder(streamId,
                                         outputStreamDefinition, EventHolder.STREAM, false);
+                                streamDataHolder.setInmemoryTopicName(topic);
                                 streamDataHolder.addPublishingStrategy(
                                         new PublishingStrategyDataHolder(TransportStrategy.ALL,
                                                 DEFAULT_PARALLEL));
@@ -210,11 +212,13 @@ public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
                         if (annotation.getName().equalsIgnoreCase(SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER
                                 .replace("@", ""))) {
                             if (annotation.getElement("type").equalsIgnoreCase(INMEMORY)) {
+                                String topic = annotation.getElement("topic");
                                 String runtimeStreamDefinition = removeMetaInfoStream(streamId,
                                         inputStreamDataHolder.getStreamDefinition(),
                                         SiddhiTopologyCreatorConstants.SOURCE_IDENTIFIER, INMEMORY);
                                 String inputStreamDefinition = "${" + streamId + "} " + runtimeStreamDefinition;
                                 inputStreamDataHolder.setStreamDefinition(inputStreamDefinition);
+                                inputStreamDataHolder.setInMemoryTopic(topic);
                                 inputStreamDataHolder.setUserGiven(false);
                             }
                         }


### PR DESCRIPTION
## Purpose
> $subject

## Approach
> At the moment, we were creating the topic automatically merging the app name + and stream name. This wouldn't work for in-memory bridges since multiple apps might share the topic. Hence, in-memory brides we'll be using the user given topic itself.