### PR TITLE
Add syntax and example generation function for editor extension platte

### DIFF
--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ExampleMetaData.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ExampleMetaData.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.distribution.editor.core.commons.metadata;
+
+/**
+ * For storing example meta data of a processor or expression executor
+ * Used in JSON responses.
+ */
+public class ExampleMetaData {
+    private String syntax;
+    private String description;
+
+    public ExampleMetaData(String syntax, String description) {
+        this.syntax = syntax;
+        this.description = description;
+    }
+
+    public String getSyntax() {
+        return syntax;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+}

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ExampleMetaData.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ExampleMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -22,23 +22,19 @@ package io.siddhi.distribution.editor.core.commons.metadata;
  * Used in JSON responses.
  */
 public class ExampleMetaData {
-
     private String syntax;
     private String description;
 
     public ExampleMetaData(String syntax, String description) {
-
         this.syntax = syntax;
         this.description = description;
     }
 
     public String getSyntax() {
-
         return syntax;
     }
 
     public String getDescription() {
-
         return description;
     }
 

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ExampleMetaData.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ExampleMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -22,19 +22,23 @@ package io.siddhi.distribution.editor.core.commons.metadata;
  * Used in JSON responses.
  */
 public class ExampleMetaData {
+
     private String syntax;
     private String description;
 
     public ExampleMetaData(String syntax, String description) {
+
         this.syntax = syntax;
         this.description = description;
     }
 
     public String getSyntax() {
+
         return syntax;
     }
 
     public String getDescription() {
+
         return description;
     }
 

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/MetaData.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/MetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/MetaData.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/MetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ParameterMetaData.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ParameterMetaData.java
@@ -55,12 +55,10 @@ public class ParameterMetaData {
     }
 
     public Boolean isDynamic() {
-
         return dynamic;
     }
 
     public void setDynamic(Boolean dynamic) {
-
         this.dynamic = dynamic;
     }
 

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ParameterMetaData.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ParameterMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -29,6 +29,7 @@ public class ParameterMetaData {
 
     private String name;
     private List<DataType> type;
+    private Boolean dynamic;
     private Boolean optional;
     private String description;
     private String defaultValue;
@@ -51,6 +52,16 @@ public class ParameterMetaData {
     public void setType(List<DataType> type) {
 
         this.type = type;
+    }
+
+    public Boolean getDynamic() {
+
+        return dynamic;
+    }
+
+    public void setDynamic(Boolean dynamic) {
+
+        this.dynamic = dynamic;
     }
 
     public Boolean getOptional() {

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ParameterMetaData.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ParameterMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -54,7 +54,7 @@ public class ParameterMetaData {
         this.type = type;
     }
 
-    public Boolean getDynamic() {
+    public Boolean isDynamic() {
 
         return dynamic;
     }

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ProcessorMetaData.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ProcessorMetaData.java
@@ -55,12 +55,10 @@ public class ProcessorMetaData {
     }
 
     public List<ExampleMetaData> getExamples() {
-
         return examples;
     }
 
     public void setExamples(List<ExampleMetaData> examples) {
-
         this.examples = examples;
     }
 
@@ -105,12 +103,10 @@ public class ProcessorMetaData {
     }
 
     public List<SyntaxMetaData> getSyntax() {
-
         return syntax;
     }
 
     public void setSyntax(List<SyntaxMetaData> syntax) {
-
         this.syntax = syntax;
     }
 

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ProcessorMetaData.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ProcessorMetaData.java
@@ -17,7 +17,7 @@
  */
 package io.siddhi.distribution.editor.core.commons.metadata;
 
-import java.util.Arrays;
+
 import java.util.List;
 
 /**
@@ -28,11 +28,12 @@ public class ProcessorMetaData {
 
     private String name;
     private String namespace;
+    private List<SyntaxMetaData> syntax;
     private String description;
     private List<ParameterMetaData> parameters;
     private List<String[]> parameterOverloads;
     private List<AttributeMetaData> returnAttributes;
-    private String[] examples;
+    private List<ExampleMetaData> examples;
 
     public String getName() {
 
@@ -54,14 +55,14 @@ public class ProcessorMetaData {
         this.namespace = namespace;
     }
 
-    public String[] getExamples() {
+    public List<SyntaxMetaData> getSyntax() {
 
-        return (examples != null) ? Arrays.copyOf(examples, examples.length) : new String[0];
+        return syntax;
     }
 
-    public void setExamples(String[] examples) {
+    public void setSyntax(List<SyntaxMetaData>  syntax) {
 
-        this.examples = (examples != null) ? Arrays.copyOf(examples, examples.length) : null;
+        this.syntax = syntax;
     }
 
     public String getDescription() {
@@ -84,24 +85,34 @@ public class ProcessorMetaData {
         this.parameters = parameters;
     }
 
+    public void setReturnAttributes(List<AttributeMetaData> returnAttributes) {
+
+        this.returnAttributes = returnAttributes;
+    }
     public List<AttributeMetaData> getReturnAttributes() {
 
         return returnAttributes;
     }
 
-    public void setReturnAttributes(List<AttributeMetaData> returnAttributes) {
-
-        this.returnAttributes = returnAttributes;
-    }
 
     public void setParameterOverloads(List<String[]> parameterOverloads) {
-
         this.parameterOverloads = parameterOverloads;
     }
+
 
     public List<String[]> getParameterOverloads() {
 
         return parameterOverloads;
     }
+    public List<ExampleMetaData> getExamples() {
+
+        return examples;
+    }
+
+    public void setExamples(List<ExampleMetaData> examples) {
+
+        this.examples = examples;
+    }
 
 }
+

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ProcessorMetaData.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/ProcessorMetaData.java
@@ -17,7 +17,6 @@
  */
 package io.siddhi.distribution.editor.core.commons.metadata;
 
-
 import java.util.List;
 
 /**
@@ -28,12 +27,12 @@ public class ProcessorMetaData {
 
     private String name;
     private String namespace;
-    private List<SyntaxMetaData> syntax;
+    private List<ExampleMetaData> examples;
     private String description;
     private List<ParameterMetaData> parameters;
     private List<String[]> parameterOverloads;
     private List<AttributeMetaData> returnAttributes;
-    private List<ExampleMetaData> examples;
+    private List<SyntaxMetaData> syntax;
 
     public String getName() {
 
@@ -55,14 +54,14 @@ public class ProcessorMetaData {
         this.namespace = namespace;
     }
 
-    public List<SyntaxMetaData> getSyntax() {
+    public List<ExampleMetaData> getExamples() {
 
-        return syntax;
+        return examples;
     }
 
-    public void setSyntax(List<SyntaxMetaData>  syntax) {
+    public void setExamples(List<ExampleMetaData> examples) {
 
-        this.syntax = syntax;
+        this.examples = examples;
     }
 
     public String getDescription() {
@@ -89,29 +88,30 @@ public class ProcessorMetaData {
 
         this.returnAttributes = returnAttributes;
     }
+
     public List<AttributeMetaData> getReturnAttributes() {
 
         return returnAttributes;
     }
 
-
     public void setParameterOverloads(List<String[]> parameterOverloads) {
+
         this.parameterOverloads = parameterOverloads;
     }
-
 
     public List<String[]> getParameterOverloads() {
 
         return parameterOverloads;
     }
-    public List<ExampleMetaData> getExamples() {
 
-        return examples;
+    public List<SyntaxMetaData> getSyntax() {
+
+        return syntax;
     }
 
-    public void setExamples(List<ExampleMetaData> examples) {
+    public void setSyntax(List<SyntaxMetaData> syntax) {
 
-        this.examples = examples;
+        this.syntax = syntax;
     }
 
 }

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/SyntaxMetaData.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/SyntaxMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -22,20 +22,24 @@ package io.siddhi.distribution.editor.core.commons.metadata;
  * Used in JSON responses.
  */
 public class SyntaxMetaData {
+
     private String syntax;
     private String clipboardSyntax;
+
+    public SyntaxMetaData(String syntax, String clipboardSyntax) {
+
+        this.syntax = syntax;
+        this.clipboardSyntax = clipboardSyntax;
+    }
+
     public String getSyntax() {
+
         return syntax;
     }
 
-    public void setSyntax(String syntax) {
-        this.syntax = syntax;
-    }
     public String getClipboardSyntax() {
+
         return clipboardSyntax;
-    }
-    public void setClipboardSyntax(String clipboardSyntax) {
-        this.clipboardSyntax = clipboardSyntax;
     }
 
 }

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/SyntaxMetaData.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/SyntaxMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -22,23 +22,19 @@ package io.siddhi.distribution.editor.core.commons.metadata;
  * Used in JSON responses.
  */
 public class SyntaxMetaData {
-
     private String syntax;
     private String clipboardSyntax;
 
     public SyntaxMetaData(String syntax, String clipboardSyntax) {
-
         this.syntax = syntax;
         this.clipboardSyntax = clipboardSyntax;
     }
 
     public String getSyntax() {
-
         return syntax;
     }
 
     public String getClipboardSyntax() {
-
         return clipboardSyntax;
     }
 

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/SyntaxMetaData.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/commons/metadata/SyntaxMetaData.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.distribution.editor.core.commons.metadata;
+
+/**
+ * For storing syntax meta data of a processor or expression executor
+ * Used in JSON responses.
+ */
+public class SyntaxMetaData {
+    private String syntax;
+    private String clipboardSyntax;
+    public String getSyntax() {
+        return syntax;
+    }
+
+    public void setSyntax(String syntax) {
+        this.syntax = syntax;
+    }
+    public String getClipboardSyntax() {
+        return clipboardSyntax;
+    }
+    public void setClipboardSyntax(String clipboardSyntax) {
+        this.clipboardSyntax = clipboardSyntax;
+    }
+
+}

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/util/SourceEditorUtils.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/util/SourceEditorUtils.java
@@ -440,7 +440,7 @@ public class SourceEditorUtils {
     }
 
     /**
-     * generate the parameter data type syntax for extension syntax generation
+     * generate the parameter data type syntax for extension syntax generation.
      *
      * @param parameterName        parameter name from parameter
      * @param parameterDataTypeMap Parameter datatype map
@@ -450,7 +450,7 @@ public class SourceEditorUtils {
                                                              Map<String, DataType[]> parameterDataTypeMap) {
 
         StringBuilder parameterDataType = new StringBuilder();
-        parameterDataType.append("<");
+        parameterDataType.append(" <");
         DataType[] parameterType = parameterDataTypeMap.get(parameterName);
         for (int i = 0; i < parameterType.length; i++) {
             DataType dataType = parameterType[i];
@@ -460,12 +460,12 @@ public class SourceEditorUtils {
                 parameterDataType.append(dataType);
             }
         }
-        parameterDataType.append(">");
+        parameterDataType.append("> ");
         return parameterDataType;
     }
 
     /**
-     * generate the syntax  for functions,windows,stream processor and aggregate function
+     * generate the syntax  for functions,windows,stream processor and aggregate function.
      *
      * @param extension            Extension data from extension anotation
      * @param parameterDataTypeMap Parameter datatype map
@@ -488,7 +488,7 @@ public class SourceEditorUtils {
                     syntax.append(returnAttribute.type()[j]);
                 }
             }
-            syntax.append(">");
+            syntax.append("> ");
         }
 
         // Add name syntax to the extension
@@ -515,7 +515,7 @@ public class SourceEditorUtils {
                 } else {
                     String previousDataname;
                     parameterSyntax.append("(");
-                    parameterClipboardSyntax.append("(");
+                    parameterClipboardSyntax.append("( ");
                     for (int j = 0; j < parameterOverload.parameterNames().length; j++) {
                         String parameterName = parameterOverload.parameterNames()[j];
                         if (parameterName.equalsIgnoreCase(SiddhiCodeBuilderConstants.THREE_DOTS)) {
@@ -536,8 +536,8 @@ public class SourceEditorUtils {
                             }
                         }
                     }
-                    parameterClipboardSyntax.append(")");
-                    parameterSyntax.append(")");
+                    parameterClipboardSyntax.append(" )");
+                    parameterSyntax.append(" )");
                 }
                 finalClipBoardSyntax = clipBoardSyntax.toString() + parameterClipboardSyntax.toString();
                 finalSyntax = syntax.toString() + parameterSyntax.toString();
@@ -546,7 +546,7 @@ public class SourceEditorUtils {
             }
         } else {
             syntax.append("(");
-            clipBoardSyntax.append("(");
+            clipBoardSyntax.append("( ");
             for (int i = 0; i < extension.parameters().length; i++) {
                 Parameter parameter = extension.parameters()[i];
                 syntax.append(parameterDataTypeGeneration(parameter.name(), parameterDataTypeMap));
@@ -558,8 +558,8 @@ public class SourceEditorUtils {
                     clipBoardSyntax.append(parameter.name());
                 }
             }
-            syntax.append(")");
-            clipBoardSyntax.append(")");
+            syntax.append(" )");
+            clipBoardSyntax.append(" )");
             finalSyntax = syntax.toString();
             finalClipBoardSyntax = clipBoardSyntax.toString();
             SyntaxMetaData syntaxMetaData = new SyntaxMetaData(finalSyntax, finalClipBoardSyntax);
@@ -569,7 +569,7 @@ public class SourceEditorUtils {
     }
 
     /**
-     * generate the syntax  for source and sink extension
+     * generate the syntax  for source and sink extension.
      *
      * @param extension            Extension data from extension anotation
      * @param parameterDataTypeMap Parameter datatype map
@@ -603,7 +603,7 @@ public class SourceEditorUtils {
     }
 
     /**
-     * generate the syntax  for source mapper and sink mapper extension
+     * generate the syntax  for source mapper and sink mapper extension.
      *
      * @param extension            Extension data from extension anotation
      * @param parameterDataTypeMap Parameter datatype map
@@ -642,7 +642,7 @@ public class SourceEditorUtils {
     }
 
     /**
-     * generate the syntax  for store  extension
+     * generate the syntax  for store  extension.
      *
      * @param extension            Extension data from extension anotation
      * @param parameterDataTypeMap Parameter datatype map
@@ -732,36 +732,36 @@ public class SourceEditorUtils {
 
               /* Generate syntax annotation data for function,attribute aggregation,windows,stream
             function and stream */
-            if (Constants.FUNCTION_EXECUTOR.equalsIgnoreCase(processorType)
-                    || Constants.ATTRIBUTE_AGGREGATOR.equalsIgnoreCase(processorType) ||
-                    Constants.WINDOW_PROCESSOR.equalsIgnoreCase(processorType)
-                    || Constants.STREAM_FUNCTION_PROCESSOR.equalsIgnoreCase(processorType) ||
+            if (Constants.FUNCTION_EXECUTOR.equalsIgnoreCase(processorType) ||
+                    Constants.ATTRIBUTE_AGGREGATOR.equalsIgnoreCase(processorType) ||
+                    Constants.WINDOW_PROCESSOR.equalsIgnoreCase(processorType) ||
+                    Constants.STREAM_FUNCTION_PROCESSOR.equalsIgnoreCase(processorType) ||
                     Constants.STREAM_PROCESSOR.equalsIgnoreCase(processorType)) {
                 processorMetaData.setSyntax(windowFunctionSyntaxGeneration(extensionAnnotation,
                         parameterDataTypeMap));
             }
 
-//Generate syntax annotation data for source and sink
-            if ((Constants.SOURCE.equals(processorType))
-                    || (Constants.SINK.equals(processorType))) {
+            //Generate syntax annotation data for source and sink
+            if ((Constants.SOURCE.equals(processorType)) ||
+                    (Constants.SINK.equals(processorType))) {
                 processorMetaData.setSyntax(sourceSinkSyntaxGeneration(extensionAnnotation,
                         parameterDataTypeMap));
             }
 
-//Generate Syntax annotation data for source mapper and sink mapper
-            if ((Constants.SOURCEMAP.equals(processorType))
-                    || (Constants.SINKMAP.equals(processorType))) {
+            //Generate Syntax annotation data for source mapper and sink mapper
+            if ((Constants.SOURCEMAP.equals(processorType)) ||
+                    (Constants.SINKMAP.equals(processorType))) {
                 processorMetaData.setSyntax(sourceSinkMapSyntaxGeneration(extensionAnnotation,
                         parameterDataTypeMap));
             }
 
-//Generate Syntax annotation data for store
+            //Generate Syntax annotation data for store
             if ((Constants.STORE.equals(processorType))) {
                 processorMetaData.setSyntax(storeSyntaxGeneration(extensionAnnotation,
                         parameterDataTypeMap));
             }
 
-//Adding Example annotation data
+            //Adding Example annotation data
             if (extensionAnnotation.examples().length > 0) {
                 // When multiple examples are present
                 List<ExampleMetaData> examplesList = new ArrayList<>();

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/util/SourceEditorUtils.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/util/SourceEditorUtils.java
@@ -42,6 +42,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -472,8 +473,7 @@ public class SourceEditorUtils {
      * @return syntaxList
      */
     private static List<SyntaxMetaData> windowFunctionSyntaxGeneration(Extension extension,
-                                                                       Map<String, DataType[]> parameterDataTypeMap
-                                                                      ) {
+                                                                       Map<String, DataType[]> parameterDataTypeMap) {
 
         List<SyntaxMetaData> syntaxList = new ArrayList<>();
         StringBuilder syntax = new StringBuilder();
@@ -500,8 +500,6 @@ public class SourceEditorUtils {
         clipBoardSyntax.append(extension.name());
 
         //Add parameter and its data type syntax to extension based on the parameter overloads
-        String finalClipBoardSyntax = null;
-        String finalSyntax = null;
         if (extension.parameterOverloads().length > 0) {
             StringBuilder parameterSyntax;
             StringBuilder parameterClipboardSyntax;
@@ -510,20 +508,18 @@ public class SourceEditorUtils {
                 parameterClipboardSyntax = new StringBuilder();
 
                 if (parameterOverload.parameterNames().length == 0) {
-                    parameterSyntax.append("(").append(")");
-                    parameterClipboardSyntax.append("(").append(")");
+                    parameterSyntax.append("()");
+                    parameterClipboardSyntax.append("()");
                 } else {
-                    String previousDataname;
                     parameterSyntax.append("(");
                     parameterClipboardSyntax.append("( ");
                     for (int j = 0; j < parameterOverload.parameterNames().length; j++) {
                         String parameterName = parameterOverload.parameterNames()[j];
                         if (parameterName.equalsIgnoreCase(SiddhiCodeBuilderConstants.THREE_DOTS)) {
-                            previousDataname = parameterOverload.parameterNames()[j - 1];
-                            parameterSyntax.append(parameterDataTypeGeneration(previousDataname,
-                                    parameterDataTypeMap)).append(SiddhiCodeBuilderConstants.THREE_DOTS);
-                            parameterClipboardSyntax.append(previousDataname)
-                                    .append(SiddhiCodeBuilderConstants.THREE_DOTS);
+                            String paramName = parameterOverload.parameterNames()[j - 1];
+                            parameterSyntax.append(parameterDataTypeGeneration(paramName, parameterDataTypeMap))
+                                            .append(SiddhiCodeBuilderConstants.THREE_DOTS);
+                            parameterClipboardSyntax.append(paramName).append(SiddhiCodeBuilderConstants.THREE_DOTS);
                         } else {
                             parameterSyntax.append(
                                     parameterDataTypeGeneration(parameterName, parameterDataTypeMap).toString());
@@ -539,9 +535,9 @@ public class SourceEditorUtils {
                     parameterClipboardSyntax.append(" )");
                     parameterSyntax.append(" )");
                 }
-                finalClipBoardSyntax = clipBoardSyntax.toString() + parameterClipboardSyntax.toString();
-                finalSyntax = syntax.toString() + parameterSyntax.toString();
-                SyntaxMetaData syntaxMetaData = new SyntaxMetaData(finalSyntax, finalClipBoardSyntax);
+                SyntaxMetaData syntaxMetaData = new SyntaxMetaData(
+                        syntax.toString() + parameterSyntax.toString(),
+                        clipBoardSyntax.toString() + parameterClipboardSyntax.toString());
                 syntaxList.add(syntaxMetaData);
             }
         } else {
@@ -560,9 +556,8 @@ public class SourceEditorUtils {
             }
             syntax.append(" )");
             clipBoardSyntax.append(" )");
-            finalSyntax = syntax.toString();
-            finalClipBoardSyntax = clipBoardSyntax.toString();
-            SyntaxMetaData syntaxMetaData = new SyntaxMetaData(finalSyntax, finalClipBoardSyntax);
+
+            SyntaxMetaData syntaxMetaData = new SyntaxMetaData(syntax.toString(), clipBoardSyntax.toString());
             syntaxList.add(syntaxMetaData);
         }
         return syntaxList;
@@ -585,21 +580,18 @@ public class SourceEditorUtils {
             clipBoardSyntax.append("@").append(extension.namespace());
             syntax.append("@").append(extension.namespace());
         }
-        clipBoardSyntax.append("(").append("type=\"").append(extension.name());
-        clipBoardSyntax.append("\"").append(", ");
-        syntax.append("(").append("type=\"").append(extension.name()).append("\"").append(", ");
+        clipBoardSyntax.append("(type=\"").append(extension.name()).append("\", ");
+        syntax.append("(type=\"").append(extension.name()).append("\", ");
 
         for (Parameter parameter : extension.parameters()) {
             clipBoardSyntax.append(parameter.name()).append(" =\"\", ");
-            syntax.append(" ").append(parameter.name()).append("=").append("\"");
-            syntax.append(parameterDataTypeGeneration(parameter.name(), parameterDataTypeMap));
-            syntax.append("\"").append(",");
+            syntax.append(" ").append(parameter.name()).append("=")
+                    .append("\"").append(parameterDataTypeGeneration(parameter.name(), parameterDataTypeMap))
+                    .append("\",");
         }
         SyntaxMetaData syntaxMetaData = new SyntaxMetaData(syntax.append(" @map (...))").toString(),
                 clipBoardSyntax.append(" @map (...))").toString());
-        List<SyntaxMetaData> syntaxList = new ArrayList<>();
-        syntaxList.add(syntaxMetaData);
-        return syntaxList;
+        return Collections.singletonList(syntaxMetaData);
     }
 
     /**
@@ -610,35 +602,31 @@ public class SourceEditorUtils {
      * @return syntaxList
      */
     private static List<SyntaxMetaData> sourceSinkMapSyntaxGeneration(Extension extension,
-                                                                      Map<String, DataType[]> parameterDataTypeMap
-                                                                     ) {
+                                                                      Map<String, DataType[]> parameterDataTypeMap) {
 
         StringBuilder syntax = new StringBuilder();
         StringBuilder clipBoardSyntax = new StringBuilder();
         if (!extension.namespace().isEmpty()) {
             if (extension.namespace().equalsIgnoreCase("sinkMapper")) {
-                syntax.append("@").append("sink");
+                syntax.append("@sink");
             } else {
-                syntax.append("@").append("source");
+                syntax.append("@source");
             }
         }
-        clipBoardSyntax.append("@map(type= \"");
-        clipBoardSyntax.append(extension.name()).append("\"");
-        syntax.append("(").append(SiddhiCodeBuilderConstants.THREE_DOTS).append("@map(type= \"");
-        syntax.append(extension.name()).append("\"");
+        clipBoardSyntax.append("@map(type= \"").append(extension.name()).append("\"");
+        syntax.append("(").append(SiddhiCodeBuilderConstants.THREE_DOTS)
+                .append("@map(type= \"").append(extension.name()).append("\"");
 
-        for (int i = 0; i < extension.parameters().length; i++) {
-            Parameter parameter = extension.parameters()[i];
+        for (Parameter parameter : extension.parameters()) {
             clipBoardSyntax.append(", ").append(parameter.name()).append(" =\"\"");
-            syntax.append(", ").append(parameter.name()).append("=");
-            syntax.append("\"").append(parameterDataTypeGeneration(parameter.name(), parameterDataTypeMap))
+            syntax.append(", ").append(parameter.name()).append("=")
+                    .append("\"").append(parameterDataTypeGeneration(parameter.name(), parameterDataTypeMap))
                     .append("\"");
         }
+
         SyntaxMetaData syntaxMetaData = new SyntaxMetaData(syntax.append("))").toString(),
                 clipBoardSyntax.append(")").toString());
-        List<SyntaxMetaData> syntaxList = new ArrayList<>();
-        syntaxList.add(syntaxMetaData);
-        return syntaxList;
+        return Collections.singletonList(syntaxMetaData);
     }
 
     /**
@@ -657,33 +645,32 @@ public class SourceEditorUtils {
             clipBoardSyntax.append("@").append(extension.namespace());
             syntax.append("@").append(extension.namespace());
         }
-        clipBoardSyntax.append("(").append("type=\"").append(extension.name());
-        clipBoardSyntax.append("\"").append(",");
-        syntax.append("(").append("type=\"").append(extension.name());
-        syntax.append("\"").append(",");
+        clipBoardSyntax.append("(type=\"").append(extension.name()).append("\",");
+        syntax.append("(type=\"").append(extension.name()).append("\",");
 
         for (int i = 0; i < extension.parameters().length; i++) {
             Parameter parameter = extension.parameters()[i];
             if (i != extension.parameters().length - 1) {
                 clipBoardSyntax.append(" ").append(parameter.name()).append(" =\"\",");
-                syntax.append(" ").append(parameter.name()).append("=");
-                syntax.append("\"").append(parameterDataTypeGeneration(parameter.name(), parameterDataTypeMap))
-                        .append("\"").append(",");
+                syntax.append(" ").append(parameter.name()).append("=")
+                        .append("\"").append(parameterDataTypeGeneration(parameter.name(), parameterDataTypeMap))
+                        .append("\",");
             } else {
                 clipBoardSyntax.append(" ").append(parameter.name()).append(" =\"\"");
-                syntax.append(" ").append(parameter.name()).append("=");
-                syntax.append("\"").append(parameterDataTypeGeneration(parameter.name(), parameterDataTypeMap))
+                syntax.append(" ").append(parameter.name()).append("=")
+                        .append("\"").append(parameterDataTypeGeneration(parameter.name(), parameterDataTypeMap))
                         .append("\"");
             }
         }
-        String finalSyntax = syntax.append(")").append("\n").append("@PrimaryKey(\"PRIMARY_KEY\")")
-                .append("\n").append("@Index(\"INDEX\")").toString();
-        String finalClipBoardSyntax = clipBoardSyntax.append(")").append("\n").append("@PrimaryKey(\"PRIMARY_KEY\")")
-                .append("\n").append("@Index(\"INDEX\")").toString();
-        SyntaxMetaData syntaxMetaData = new SyntaxMetaData(finalSyntax, finalClipBoardSyntax);
-        List<SyntaxMetaData> syntaxList = new ArrayList<>();
-        syntaxList.add(syntaxMetaData);
-        return syntaxList;
+        syntax.append(")\n")
+                .append("@PrimaryKey(\"PRIMARY_KEY\")\n")
+                .append("@Index(\"INDEX\")");
+        clipBoardSyntax.append(")\n")
+                .append("@PrimaryKey(\"PRIMARY_KEY\")\n")
+                .append("@Index(\"INDEX\")");
+
+        SyntaxMetaData syntaxMetaData = new SyntaxMetaData(syntax.toString(), clipBoardSyntax.toString());
+        return Collections.singletonList(syntaxMetaData);
     }
 
     /**
@@ -713,8 +700,8 @@ public class SourceEditorUtils {
 
             //  Adding Parameter annotation data
             //define parameter map to generate parameter syntax
-            Map<String, DataType[]> parameterDataTypeMap = new HashMap<String, DataType[]>();
-            if (extensionAnnotation.parameters().length > 0) { // When multiple parameters are present
+            Map<String, DataType[]> parameterDataTypeMap = new HashMap<>();
+            if (extensionAnnotation.parameters().length > 0) {
                 List<ParameterMetaData> parameterMetaDataList = new ArrayList<>();
                 for (Parameter parameter : extensionAnnotation.parameters()) {
                     ParameterMetaData parameterMetaData = new ParameterMetaData();
@@ -730,48 +717,43 @@ public class SourceEditorUtils {
                 processorMetaData.setParameters(parameterMetaDataList);
             }
 
-              /* Generate syntax annotation data for function,attribute aggregation,windows,stream
-            function and stream */
+            // Generate syntax annotation data for function, attribute aggregation,windows,stream
+            // function and stream
             if (Constants.FUNCTION_EXECUTOR.equalsIgnoreCase(processorType) ||
                     Constants.ATTRIBUTE_AGGREGATOR.equalsIgnoreCase(processorType) ||
                     Constants.WINDOW_PROCESSOR.equalsIgnoreCase(processorType) ||
                     Constants.STREAM_FUNCTION_PROCESSOR.equalsIgnoreCase(processorType) ||
                     Constants.STREAM_PROCESSOR.equalsIgnoreCase(processorType)) {
-                processorMetaData.setSyntax(windowFunctionSyntaxGeneration(extensionAnnotation,
-                        parameterDataTypeMap));
+                processorMetaData.setSyntax(
+                        windowFunctionSyntaxGeneration(extensionAnnotation, parameterDataTypeMap));
             }
 
             //Generate syntax annotation data for source and sink
-            if ((Constants.SOURCE.equals(processorType)) ||
-                    (Constants.SINK.equals(processorType))) {
-                processorMetaData.setSyntax(sourceSinkSyntaxGeneration(extensionAnnotation,
-                        parameterDataTypeMap));
+            if (Constants.SOURCE.equals(processorType) || Constants.SINK.equals(processorType)) {
+                processorMetaData.setSyntax(
+                        sourceSinkSyntaxGeneration(extensionAnnotation, parameterDataTypeMap));
             }
 
             //Generate Syntax annotation data for source mapper and sink mapper
-            if ((Constants.SOURCEMAP.equals(processorType)) ||
-                    (Constants.SINKMAP.equals(processorType))) {
-                processorMetaData.setSyntax(sourceSinkMapSyntaxGeneration(extensionAnnotation,
-                        parameterDataTypeMap));
+            if (Constants.SOURCEMAP.equals(processorType) || Constants.SINKMAP.equals(processorType)) {
+                processorMetaData.setSyntax(
+                        sourceSinkMapSyntaxGeneration(extensionAnnotation, parameterDataTypeMap));
             }
 
             //Generate Syntax annotation data for store
-            if ((Constants.STORE.equals(processorType))) {
-                processorMetaData.setSyntax(storeSyntaxGeneration(extensionAnnotation,
-                        parameterDataTypeMap));
+            if (Constants.STORE.equals(processorType)) {
+                processorMetaData.setSyntax(
+                        storeSyntaxGeneration(extensionAnnotation, parameterDataTypeMap));
             }
 
             //Adding Example annotation data
-            if (extensionAnnotation.examples().length > 0) {
-                // When multiple examples are present
-                List<ExampleMetaData> examplesList = new ArrayList<>();
-                for (Example exampleAnnotation : extensionAnnotation.examples()) {
-                    ExampleMetaData exampleMetaData =
-                            new ExampleMetaData(exampleAnnotation.syntax(), exampleAnnotation.description());
-                    examplesList.add(exampleMetaData);
-                }
-                processorMetaData.setExamples(examplesList);
+            List<ExampleMetaData> examplesList = new ArrayList<>();
+            for (Example exampleAnnotation : extensionAnnotation.examples()) {
+                ExampleMetaData exampleMetaData =
+                        new ExampleMetaData(exampleAnnotation.syntax(), exampleAnnotation.description());
+                examplesList.add(exampleMetaData);
             }
+            processorMetaData.setExamples(examplesList);
 
             // Adding ReturnEvent annotation data
             // Adding return event additional attributes

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/util/SourceEditorUtils.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/util/SourceEditorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -439,45 +439,58 @@ public class SourceEditorUtils {
         }
     }
 
-    //generate the parameter data type syntax for extension syntax generation
+    /**
+     * generate the parameter data type syntax for extension syntax generation
+     *
+     * @param parameterName        parameter name from parameter
+     * @param parameterDataTypeMap Parameter datatype map
+     * @return Parameter Data Type
+     */
     private static StringBuilder parameterDataTypeGeneration(String parameterName,
-                                                             HashMap<String, DataType[]> parameterMap) {
+                                                             Map<String, DataType[]> parameterDataTypeMap) {
 
         StringBuilder parameterDataType = new StringBuilder();
         parameterDataType.append("<");
-        DataType[] parameterType = parameterMap.get(parameterName);
+        DataType[] parameterType = parameterDataTypeMap.get(parameterName);
         for (int i = 0; i < parameterType.length; i++) {
             DataType dataType = parameterType[i];
-            if (i == parameterType.length - 1) {
-                parameterDataType.append(dataType);
-            } else {
+            if (i != parameterType.length - 1) {
                 parameterDataType.append(dataType).append("|");
+            } else {
+                parameterDataType.append(dataType);
             }
         }
         parameterDataType.append(">");
         return parameterDataType;
     }
 
-    /*generate the syntax  for functions,windows,stream processor and aggregate
-     function*/
+    /**
+     * generate the syntax  for functions,windows,stream processor and aggregate function
+     *
+     * @param extension            Extension data from extension anotation
+     * @param parameterDataTypeMap Parameter datatype map
+     * @return syntaxList
+     */
     private static List<SyntaxMetaData> windowFunctionSyntaxGeneration(Extension extension,
-                                                                       HashMap<String, DataType[]> parameterMap,
-                                                                       List<SyntaxMetaData> syntaxList,
-                                                                       String finalClipBoardSyntax, String finalSyntax,
-                                                                       StringBuilder syntax,
-                                                                       StringBuilder clipBoardSyntax) {
+                                                                       Map<String, DataType[]> parameterDataTypeMap
+                                                                      ) {
+
+        List<SyntaxMetaData> syntaxList = new ArrayList<>();
+        StringBuilder syntax = new StringBuilder();
+        StringBuilder clipBoardSyntax = new StringBuilder();
         //Add return syntax to the extension if it is a functions and aggregate functions
         for (ReturnAttribute returnAttribute : extension.returnAttributes()) {
             syntax.append("<");
             for (int j = 0; j < (returnAttribute.type()).length; j++) {
-                if (j == returnAttribute.type().length - 1) {
-                    syntax.append(returnAttribute.type()[j]);
-                } else {
+                if (j != returnAttribute.type().length - 1) {
                     syntax.append(returnAttribute.type()[j]).append("|");
+                } else {
+                    syntax.append(returnAttribute.type()[j]);
                 }
             }
             syntax.append(">");
         }
+
         // Add name syntax to the extension
         if (!extension.namespace().isEmpty()) {
             syntax.append(extension.namespace()).append(":");
@@ -485,88 +498,89 @@ public class SourceEditorUtils {
         }
         syntax.append(extension.name());
         clipBoardSyntax.append(extension.name());
+
         //Add parameter and its data type syntax to extension based on the parameter overloads
+        String finalClipBoardSyntax = null;
+        String finalSyntax = null;
         if (extension.parameterOverloads().length > 0) {
             StringBuilder parameterSyntax;
-            StringBuilder parameterSyntaxClipboard;
+            StringBuilder parameterClipboardSyntax;
             for (ParameterOverload parameterOverload : extension.parameterOverloads()) {
-                SyntaxMetaData syntaxMetaData = new SyntaxMetaData();
                 parameterSyntax = new StringBuilder();
-                parameterSyntaxClipboard = new StringBuilder();
-                String previousDataname;
+                parameterClipboardSyntax = new StringBuilder();
 
                 if (parameterOverload.parameterNames().length == 0) {
                     parameterSyntax.append("(").append(")");
-                    parameterSyntaxClipboard.append("(").append(")");
+                    parameterClipboardSyntax.append("(").append(")");
                 } else {
+                    String previousDataname;
                     parameterSyntax.append("(");
-                    parameterSyntaxClipboard.append("(");
+                    parameterClipboardSyntax.append("(");
                     for (int j = 0; j < parameterOverload.parameterNames().length; j++) {
                         String parameterName = parameterOverload.parameterNames()[j];
                         if (parameterName.equalsIgnoreCase(SiddhiCodeBuilderConstants.THREE_DOTS)) {
                             previousDataname = parameterOverload.parameterNames()[j - 1];
                             parameterSyntax.append(parameterDataTypeGeneration(previousDataname,
-                                    parameterMap)).append(SiddhiCodeBuilderConstants.THREE_DOTS);
-                            parameterSyntaxClipboard.append(previousDataname)
+                                    parameterDataTypeMap)).append(SiddhiCodeBuilderConstants.THREE_DOTS);
+                            parameterClipboardSyntax.append(previousDataname)
                                     .append(SiddhiCodeBuilderConstants.THREE_DOTS);
                         } else {
                             parameterSyntax.append(
-                                    parameterDataTypeGeneration(parameterName, parameterMap).toString());
-                            if (j == parameterOverload.parameterNames().length - 1) {
-                                parameterSyntax.append(parameterName);
-                                parameterSyntaxClipboard.append(parameterName);
-                            } else {
+                                    parameterDataTypeGeneration(parameterName, parameterDataTypeMap).toString());
+                            if (j != parameterOverload.parameterNames().length - 1) {
                                 parameterSyntax.append(parameterName).append(",");
-                                parameterSyntaxClipboard.append(parameterName).append(",");
+                                parameterClipboardSyntax.append(parameterName).append(",");
+                            } else {
+                                parameterSyntax.append(parameterName);
+                                parameterClipboardSyntax.append(parameterName);
                             }
                         }
                     }
-                    parameterSyntaxClipboard.append(")");
+                    parameterClipboardSyntax.append(")");
                     parameterSyntax.append(")");
                 }
-                finalClipBoardSyntax = clipBoardSyntax.toString() + parameterSyntaxClipboard.toString();
+                finalClipBoardSyntax = clipBoardSyntax.toString() + parameterClipboardSyntax.toString();
                 finalSyntax = syntax.toString() + parameterSyntax.toString();
-
-                syntaxMetaData.setSyntax(finalSyntax);
-                syntaxMetaData.setClipboardSyntax(finalClipBoardSyntax);
+                SyntaxMetaData syntaxMetaData = new SyntaxMetaData(finalSyntax, finalClipBoardSyntax);
                 syntaxList.add(syntaxMetaData);
             }
         } else {
-            SyntaxMetaData syntaxMetaData = new SyntaxMetaData();
             syntax.append("(");
             clipBoardSyntax.append("(");
             for (int i = 0; i < extension.parameters().length; i++) {
                 Parameter parameter = extension.parameters()[i];
-                syntax.append(parameterDataTypeGeneration(parameter.name(), parameterMap));
-                if (i == extension.parameters().length - 1) {
-                    syntax.append(parameter.name());
-                    clipBoardSyntax.append(parameter.name());
-                } else {
+                syntax.append(parameterDataTypeGeneration(parameter.name(), parameterDataTypeMap));
+                if (i != extension.parameters().length - 1) {
                     syntax.append(parameter.name()).append(",");
                     clipBoardSyntax.append(parameter.name()).append(",");
+                } else {
+                    syntax.append(parameter.name());
+                    clipBoardSyntax.append(parameter.name());
                 }
             }
             syntax.append(")");
             clipBoardSyntax.append(")");
             finalSyntax = syntax.toString();
             finalClipBoardSyntax = clipBoardSyntax.toString();
-
-            syntaxMetaData.setSyntax(finalSyntax);
-            syntaxMetaData.setClipboardSyntax(finalClipBoardSyntax);
+            SyntaxMetaData syntaxMetaData = new SyntaxMetaData(finalSyntax, finalClipBoardSyntax);
             syntaxList.add(syntaxMetaData);
         }
-
         return syntaxList;
     }
 
-    /*generate the syntax  for source and sink extension*/
+    /**
+     * generate the syntax  for source and sink extension
+     *
+     * @param extension            Extension data from extension anotation
+     * @param parameterDataTypeMap Parameter datatype map
+     * @return syntaxList
+     */
     private static List<SyntaxMetaData> sourceSinkSyntaxGeneration(Extension extension,
-                                                                   HashMap<String, DataType[]> parameterMap,
-                                                                   List<SyntaxMetaData> syntaxList,
-                                                                   String finalClipBoardSyntax, String finalSyntax,
-                                                                   StringBuilder syntax,
-                                                                   StringBuilder clipBoardSyntax) {
+                                                                   Map<String, DataType[]> parameterDataTypeMap
+                                                                  ) {
 
+        StringBuilder syntax = new StringBuilder();
+        StringBuilder clipBoardSyntax = new StringBuilder();
         if (!extension.namespace().isEmpty()) {
             clipBoardSyntax.append("@").append(extension.namespace());
             syntax.append("@").append(extension.namespace());
@@ -575,33 +589,32 @@ public class SourceEditorUtils {
         clipBoardSyntax.append("\"").append(", ");
         syntax.append("(").append("type=\"").append(extension.name()).append("\"").append(", ");
 
-        StringBuilder parameterSyntaxClipboard = new StringBuilder();
-        StringBuilder parameterSyntax = new StringBuilder();
-        for (int i = 0; i < extension.parameters().length; i++) {
-            Parameter parameter = extension.parameters()[i];
-            parameterSyntaxClipboard.append(parameter.name()).append(" =\"\", ");
-            parameterSyntax.append(" ").append(parameter.name()).append("=").append("\"");
-            parameterSyntax.append(parameterDataTypeGeneration(parameter.name(), parameterMap));
-            parameterSyntax.append("\"").append(",");
+        for (Parameter parameter : extension.parameters()) {
+            clipBoardSyntax.append(parameter.name()).append(" =\"\", ");
+            syntax.append(" ").append(parameter.name()).append("=").append("\"");
+            syntax.append(parameterDataTypeGeneration(parameter.name(), parameterDataTypeMap));
+            syntax.append("\"").append(",");
         }
-        finalSyntax = syntax.toString() + parameterSyntax.toString() + " @map (...))";
-        finalClipBoardSyntax = clipBoardSyntax.toString() + parameterSyntaxClipboard.toString() + " @map (...))";
-
-        SyntaxMetaData syntaxMetaData = new SyntaxMetaData();
-        syntaxMetaData.setSyntax(finalSyntax);
-        syntaxMetaData.setClipboardSyntax(finalClipBoardSyntax);
+        SyntaxMetaData syntaxMetaData = new SyntaxMetaData(syntax.append(" @map (...))").toString(),
+                clipBoardSyntax.append(" @map (...))").toString());
+        List<SyntaxMetaData> syntaxList = new ArrayList<>();
         syntaxList.add(syntaxMetaData);
         return syntaxList;
     }
 
-    /*generate the syntax  for source mapper and sink mapper extension*/
+    /**
+     * generate the syntax  for source mapper and sink mapper extension
+     *
+     * @param extension            Extension data from extension anotation
+     * @param parameterDataTypeMap Parameter datatype map
+     * @return syntaxList
+     */
     private static List<SyntaxMetaData> sourceSinkMapSyntaxGeneration(Extension extension,
-                                                                      HashMap<String, DataType[]> parameterMap,
-                                                                      List<SyntaxMetaData> syntaxList,
-                                                                      String finalClipBoardSyntax, String finalSyntax,
-                                                                      StringBuilder syntax,
-                                                                      StringBuilder clipBoardSyntax) {
+                                                                      Map<String, DataType[]> parameterDataTypeMap
+                                                                     ) {
 
+        StringBuilder syntax = new StringBuilder();
+        StringBuilder clipBoardSyntax = new StringBuilder();
         if (!extension.namespace().isEmpty()) {
             if (extension.namespace().equalsIgnoreCase("sinkMapper")) {
                 syntax.append("@").append("sink");
@@ -614,31 +627,32 @@ public class SourceEditorUtils {
         syntax.append("(").append(SiddhiCodeBuilderConstants.THREE_DOTS).append("@map(type= \"");
         syntax.append(extension.name()).append("\"");
 
-        StringBuilder parameterSyntaxClipboard = new StringBuilder();
-        StringBuilder parameterSyntax = new StringBuilder();
         for (int i = 0; i < extension.parameters().length; i++) {
             Parameter parameter = extension.parameters()[i];
-            parameterSyntaxClipboard.append(", ").append(parameter.name()).append(" =\"\"");
-            parameterSyntax.append(", ").append(parameter.name()).append("=");
-            parameterSyntax.append("\"").append(parameterDataTypeGeneration(parameter.name(), parameterMap))
+            clipBoardSyntax.append(", ").append(parameter.name()).append(" =\"\"");
+            syntax.append(", ").append(parameter.name()).append("=");
+            syntax.append("\"").append(parameterDataTypeGeneration(parameter.name(), parameterDataTypeMap))
                     .append("\"");
         }
-        finalSyntax = syntax.toString() + parameterSyntax.toString() + "))";
-        finalClipBoardSyntax = clipBoardSyntax.toString() + parameterSyntaxClipboard.toString() + ")";
-        SyntaxMetaData syntaxMetaData = new SyntaxMetaData();
-        syntaxMetaData.setSyntax(finalSyntax);
-        syntaxMetaData.setClipboardSyntax(finalClipBoardSyntax);
+        SyntaxMetaData syntaxMetaData = new SyntaxMetaData(syntax.append("))").toString(),
+                clipBoardSyntax.append(")").toString());
+        List<SyntaxMetaData> syntaxList = new ArrayList<>();
         syntaxList.add(syntaxMetaData);
         return syntaxList;
     }
 
-    /*generate the syntax  for store  extension*/
+    /**
+     * generate the syntax  for store  extension
+     *
+     * @param extension            Extension data from extension anotation
+     * @param parameterDataTypeMap Parameter datatype map
+     * @return syntaxList
+     */
     private static List<SyntaxMetaData> storeSyntaxGeneration(Extension extension,
-                                                              HashMap<String, DataType[]> parameterMap,
-                                                              List<SyntaxMetaData> syntaxList,
-                                                              String finalClipBoardSyntax, String finalSyntax,
-                                                              StringBuilder syntax, StringBuilder clipBoardSyntax) {
+                                                              Map<String, DataType[]> parameterDataTypeMap) {
 
+        StringBuilder syntax = new StringBuilder();
+        StringBuilder clipBoardSyntax = new StringBuilder();
         if (!extension.namespace().isEmpty()) {
             clipBoardSyntax.append("@").append(extension.namespace());
             syntax.append("@").append(extension.namespace());
@@ -648,33 +662,26 @@ public class SourceEditorUtils {
         syntax.append("(").append("type=\"").append(extension.name());
         syntax.append("\"").append(",");
 
-        StringBuilder parameterSyntaxClipboard = new StringBuilder();
-        StringBuilder parameterSyntax = new StringBuilder();
         for (int i = 0; i < extension.parameters().length; i++) {
             Parameter parameter = extension.parameters()[i];
-            if (i == extension.parameters().length - 1) {
-                parameterSyntaxClipboard.append(" ").append(parameter.name()).append(" =\"\"");
-                parameterSyntax.append(" ").append(parameter.name()).append("=");
-                parameterSyntax.append("\"").append(parameterDataTypeGeneration(parameter.name(), parameterMap))
-                        .append("\"");
-            } else {
-                parameterSyntaxClipboard.append(" ").append(parameter.name()).append(" =\"\",");
-                parameterSyntax.append(" ").append(parameter.name()).append("=");
-                parameterSyntax.append("\"").append(parameterDataTypeGeneration(parameter.name(), parameterMap))
+            if (i != extension.parameters().length - 1) {
+                clipBoardSyntax.append(" ").append(parameter.name()).append(" =\"\",");
+                syntax.append(" ").append(parameter.name()).append("=");
+                syntax.append("\"").append(parameterDataTypeGeneration(parameter.name(), parameterDataTypeMap))
                         .append("\"").append(",");
+            } else {
+                clipBoardSyntax.append(" ").append(parameter.name()).append(" =\"\"");
+                syntax.append(" ").append(parameter.name()).append("=");
+                syntax.append("\"").append(parameterDataTypeGeneration(parameter.name(), parameterDataTypeMap))
+                        .append("\"");
             }
         }
-        finalSyntax = syntax.toString()
-                + parameterSyntax.toString() + ")"
-                + "\n" + "@PrimaryKey(\"PRIMARY_KEY\")"
-                + "\n" + "@Index(\"INDEX\")";
-        finalClipBoardSyntax = clipBoardSyntax.toString() + parameterSyntaxClipboard.toString() + ")"
-                + "\n" + "@PrimaryKey(\"PRIMARY_KEY\")"
-                + "\n" + "@Index(\"INDEX\")";
-
-        SyntaxMetaData syntaxMetaData = new SyntaxMetaData();
-        syntaxMetaData.setSyntax(finalSyntax);
-        syntaxMetaData.setClipboardSyntax(finalClipBoardSyntax);
+        String finalSyntax = syntax.append(")").append("\n").append("@PrimaryKey(\"PRIMARY_KEY\")")
+                .append("\n").append("@Index(\"INDEX\")").toString();
+        String finalClipBoardSyntax = clipBoardSyntax.append(")").append("\n").append("@PrimaryKey(\"PRIMARY_KEY\")")
+                .append("\n").append("@Index(\"INDEX\")").toString();
+        SyntaxMetaData syntaxMetaData = new SyntaxMetaData(finalSyntax, finalClipBoardSyntax);
+        List<SyntaxMetaData> syntaxList = new ArrayList<>();
         syntaxList.add(syntaxMetaData);
         return syntaxList;
     }
@@ -706,12 +713,12 @@ public class SourceEditorUtils {
 
             //  Adding Parameter annotation data
             //define parameter map to generate parameter syntax
-            HashMap<String, DataType[]> parameterMap = new HashMap<String, DataType[]>();
+            Map<String, DataType[]> parameterDataTypeMap = new HashMap<String, DataType[]>();
             if (extensionAnnotation.parameters().length > 0) { // When multiple parameters are present
                 List<ParameterMetaData> parameterMetaDataList = new ArrayList<>();
                 for (Parameter parameter : extensionAnnotation.parameters()) {
                     ParameterMetaData parameterMetaData = new ParameterMetaData();
-                    parameterMap.put(parameter.name(), parameter.type());
+                    parameterDataTypeMap.put(parameter.name(), parameter.type());
                     parameterMetaData.setName(parameter.name());
                     parameterMetaData.setType(Arrays.asList(parameter.type()));
                     parameterMetaData.setDynamic(parameter.dynamic());
@@ -723,11 +730,6 @@ public class SourceEditorUtils {
                 processorMetaData.setParameters(parameterMetaDataList);
             }
 
-            List<SyntaxMetaData> syntaxList = new ArrayList<>();
-            String finalClipBoardSyntax = "";
-            String finalSyntax = "";
-            StringBuilder syntax = new StringBuilder();
-            StringBuilder clipBoardSyntax = new StringBuilder();
               /* Generate syntax annotation data for function,attribute aggregation,windows,stream
             function and stream */
             if (Constants.FUNCTION_EXECUTOR.equalsIgnoreCase(processorType)
@@ -736,30 +738,30 @@ public class SourceEditorUtils {
                     || Constants.STREAM_FUNCTION_PROCESSOR.equalsIgnoreCase(processorType) ||
                     Constants.STREAM_PROCESSOR.equalsIgnoreCase(processorType)) {
                 processorMetaData.setSyntax(windowFunctionSyntaxGeneration(extensionAnnotation,
-                        parameterMap, syntaxList, finalClipBoardSyntax, finalSyntax, syntax, clipBoardSyntax));
+                        parameterDataTypeMap));
             }
 
-            /*Generate syntax annotation data for source and sink*/
+//Generate syntax annotation data for source and sink
             if ((Constants.SOURCE.equals(processorType))
                     || (Constants.SINK.equals(processorType))) {
                 processorMetaData.setSyntax(sourceSinkSyntaxGeneration(extensionAnnotation,
-                        parameterMap, syntaxList, finalClipBoardSyntax, finalSyntax, syntax, clipBoardSyntax));
+                        parameterDataTypeMap));
             }
 
-/*            Generate Syntax annotation data for source mapper and sink mapper*/
+//Generate Syntax annotation data for source mapper and sink mapper
             if ((Constants.SOURCEMAP.equals(processorType))
                     || (Constants.SINKMAP.equals(processorType))) {
                 processorMetaData.setSyntax(sourceSinkMapSyntaxGeneration(extensionAnnotation,
-                        parameterMap, syntaxList, finalClipBoardSyntax, finalSyntax, syntax, clipBoardSyntax));
+                        parameterDataTypeMap));
             }
 
-/*             Generate Syntax annotation data for store*/
+//Generate Syntax annotation data for store
             if ((Constants.STORE.equals(processorType))) {
                 processorMetaData.setSyntax(storeSyntaxGeneration(extensionAnnotation,
-                        parameterMap, syntaxList, finalClipBoardSyntax, finalSyntax, syntax, clipBoardSyntax));
+                        parameterDataTypeMap));
             }
 
-/*            Adding Example annotation data*/
+//Adding Example annotation data
             if (extensionAnnotation.examples().length > 0) {
                 // When multiple examples are present
                 List<ExampleMetaData> examplesList = new ArrayList<>();
@@ -802,6 +804,7 @@ public class SourceEditorUtils {
     }
 
     public static String populateSiddhiAppWithVars(Map<String, String> envMap, String siddhiApp) {
+
         if (siddhiApp.contains("$")) {
             String envPattern = "\\$\\{(\\w+)\\}";
             Pattern expr = Pattern.compile(envPattern);


### PR DESCRIPTION
## Purpose
> Add syntax and example generation function for siddhi editor extension Platte.

## Goals
> To improve the Siddhi Editor extension Platte.

## Approach
>In this PR I have created the java function for syntax generation of extensions and also I edit the previous example generation function of extension in order to express those examples and Syntax  in the Siddhi editor  extension Platte.