### PR TITLE
Add "credentialProvderClass" property for AWS-S3 persistence configurations

### DIFF
--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/S3PersistenceStore.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/S3PersistenceStore.java
@@ -201,8 +201,8 @@ public class S3PersistenceStore implements PersistenceStore {
 
     private AwsCredentialsProvider getCredentialProvider(Map configurationMap) {
         Object credentialProviderClassName = configurationMap.get(PersistenceConstants.CREDENTIAL_PROVIDER_CLASS);
-        if (!(credentialProviderClassName instanceof String)) { /* only to give support to previous
-            'credentialProvideClass' property */
+        if (!(credentialProviderClassName instanceof String)) { // only to give support to previous
+            // 'credentialProvideClass' property
             credentialProviderClassName = configurationMap.get(PersistenceConstants.CREDENTIAL_PROVIDER_CLASS_OLD);
         }
         if (credentialProviderClassName instanceof String) {

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/S3PersistenceStore.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/S3PersistenceStore.java
@@ -201,8 +201,8 @@ public class S3PersistenceStore implements PersistenceStore {
 
     private AwsCredentialsProvider getCredentialProvider(Map configurationMap) {
         Object credentialProviderClassName = configurationMap.get(PersistenceConstants.CREDENTIAL_PROVIDER_CLASS);
-        if (!(credentialProviderClassName instanceof String)) { // only to give support to previous
-            // 'credentialProvideClass' property
+        if (!(credentialProviderClassName instanceof String)) {
+            // only to give support to previous 'credentialProvideClass' property
             credentialProviderClassName = configurationMap.get(PersistenceConstants.CREDENTIAL_PROVIDER_CLASS_OLD);
         }
         if (credentialProviderClassName instanceof String) {

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/S3PersistenceStore.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/S3PersistenceStore.java
@@ -201,6 +201,10 @@ public class S3PersistenceStore implements PersistenceStore {
 
     private AwsCredentialsProvider getCredentialProvider(Map configurationMap) {
         Object credentialProviderClassName = configurationMap.get(PersistenceConstants.CREDENTIAL_PROVIDER_CLASS);
+        if (!(credentialProviderClassName instanceof String)) { /* only to give support to previous
+            'credentialProvideClass' property */
+            credentialProviderClassName = configurationMap.get(PersistenceConstants.CREDENTIAL_PROVIDER_CLASS_OLD);
+        }
         if (credentialProviderClassName instanceof String) {
             if (log.isDebugEnabled()) {
                 log.debug("Authenticating user via the credential provider class.");

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/beans/PersistenceStoreConfigs.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/beans/PersistenceStoreConfigs.java
@@ -37,6 +37,8 @@ public class PersistenceStoreConfigs {
     private String region;
     private String bucketName;
     private String credentialProvideClass;
+    private String credentialProviderClass; /* give support for both 'credentialProvideClass' and
+    'credentialProviderClass' property */
 
     public String getLocation() {
         return location;
@@ -76,6 +78,16 @@ public class PersistenceStoreConfigs {
 
     public void setCredentialProvideClass(String credentialProvideClass) {
         this.credentialProvideClass = credentialProvideClass;
+    }
+
+    public String getCredentialProviderClass() {
+
+        return credentialProviderClass;
+    }
+
+    public void setCredentialProviderClass(String credentialProviderClass) {
+
+        this.credentialProviderClass = credentialProviderClass;
     }
 
     public String getAccessKey() {

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/beans/PersistenceStoreConfigs.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/beans/PersistenceStoreConfigs.java
@@ -37,8 +37,8 @@ public class PersistenceStoreConfigs {
     private String region;
     private String bucketName;
     private String credentialProvideClass;
-    private String credentialProviderClass; /* give support for both 'credentialProvideClass' and
-    'credentialProviderClass' property */
+    private String credentialProviderClass; // give support for both 'credentialProvideClass' and
+    // 'credentialProviderClass' property
 
     public String getLocation() {
         return location;
@@ -81,12 +81,10 @@ public class PersistenceStoreConfigs {
     }
 
     public String getCredentialProviderClass() {
-
         return credentialProviderClass;
     }
 
     public void setCredentialProviderClass(String credentialProviderClass) {
-
         this.credentialProviderClass = credentialProviderClass;
     }
 

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/beans/PersistenceStoreConfigs.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/beans/PersistenceStoreConfigs.java
@@ -37,8 +37,8 @@ public class PersistenceStoreConfigs {
     private String region;
     private String bucketName;
     private String credentialProvideClass;
-    private String credentialProviderClass; // give support for both 'credentialProvideClass' and
-    // 'credentialProviderClass' property
+    private String credentialProviderClass;
+    // give support for both 'credentialProvideClass' and 'credentialProviderClass' property
 
     public String getLocation() {
         return location;

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/util/PersistenceConstants.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/util/PersistenceConstants.java
@@ -46,7 +46,8 @@ public class PersistenceConstants {
     public static final String SECRET_KEY = "secretKey";
     public static final String BUCKET_NAME = "bucketName";
     public static final String REGION = "region";
-    public static final String CREDENTIAL_PROVIDER_CLASS = "credentialProvideClass";
+    public static final String CREDENTIAL_PROVIDER_CLASS = "credentialProviderClass";
+    public static final String CREDENTIAL_PROVIDER_CLASS_OLD = "credentialProvideClass";
     public static final String DEFAULT_REGION_ID = "us-west-2";
     public static final int DEFAULT_REVISION_NO = 3;
 


### PR DESCRIPTION
## Purpose
> $subject

## Goals
> Give support for both 'credentialProvideClass' and 'credentialProviderClass' property

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes