### PR TITLE
Remove backend calls on keypress, and disable export when there are no files 

### DIFF
--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/commons/js/workspace/explorer-item.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/commons/js/workspace/explorer-item.js
@@ -18,9 +18,10 @@
 
 define(['lodash', 'log', 'file_browser', 'event_channel', 'context_menu', 'bootstrap'],
     function (_, log, FileBrowser, EventChannel, ContextMenu) {
-
+        var application;
         var ExplorerItem = function (args) {
             this.app = args.application;
+            application=this.app;
             this.pathSeparator = this.app.getPathSeperator();
             _.assign(this, args);
         };
@@ -42,7 +43,7 @@ define(['lodash', 'log', 'file_browser', 'event_channel', 'context_menu', 'boots
                 header = $('<div class="folder-tree-header" role="button" href="#' + id +
                     '"+ data-toggle="collapse" aria-expanded="true" aria-controls="' +
                     id + '"></div>'),
-                body = $('<div class="collapse folder-tree-body" id="' + id +
+                body = $('<div class="folder-tree-body" id="' + id +
                     '"></div>'),
                 folderIcon = $("<i class='fw fw-folder item-icon'></i>"),
                 arrowHeadIcon = $("<i class='fw fw-right expand-icon'></i>");
@@ -71,6 +72,11 @@ define(['lodash', 'log', 'file_browser', 'event_channel', 'context_menu', 'boots
 
             body.on('hide.bs.collapse', function () {
                 arrowHeadIcon.removeClass("fw-rotate-90");
+            });
+
+            body.on('ready.jstree', function () {
+                body.jstree("open_all");
+                application.workspaceManager.updateExportArtifactsItem();
             });
 
             var fileBrowser = new FileBrowser({

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/commons/js/workspace/workspace.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/commons/js/workspace/workspace.js
@@ -250,7 +250,6 @@ define(['ace/ace', 'jquery', 'lodash', 'log','dialogs','./service-client','welco
                 this.updateExportMenuItem();
                 this.updateRunMenuItem();
                 this.updateDeleteMenuItem();
-                this.updateExportArtifactsItem()
             };
 
             this.manageConsoles = function(evt){
@@ -486,30 +485,19 @@ define(['ace/ace', 'jquery', 'lodash', 'log','dialogs','./service-client','welco
 
             this.updateExportArtifactsItem = function () {
                 var exportMenuItem = app.menuBar.getMenuItemByID('export.export-for-docker'),
-                    exportKubeMenuItem = app.menuBar.getMenuItemByID('export.export-for-kubernetes');
+                    exportKubeMenuItem = app.menuBar.getMenuItemByID('export.export-for-kubernetes'),
+                    deployToServerMenuItem = app.menuBar.getMenuItemByID('deploy.deploy-to-server');
 
-                var listFilesEndpoint = app.config.services.workspace.endpoint + "/listFiles/workspace?path=" +
-                                                                        app.utils.base64EncodeUnicode("workspace");
-
-                jQuery.ajax({
-                    async: false,
-                    url: listFilesEndpoint,
-                    type: self.HTTP_GET,
-                    success: function (data) {
-                        if (data.length === 0) {
-                            exportMenuItem.disable();
-                            exportKubeMenuItem.disable();
-                        } else {
-                            exportMenuItem.enable();
-                            exportKubeMenuItem.enable();
-                        }
-                    },
-                    error: function (msg) {
-                        alerts.error("Error getting siddhi apps: " + msg.statusText);
-                        exportMenuItem.enable();
-                        exportKubeMenuItem.enable();
-                    }
-                });
+                var savedFiles = app.workspaceExplorer.treeHeader.parent().find('div[id="folder-tree_-1"] > ul').children();
+                if (savedFiles.length === 0) {
+                    exportMenuItem.disable();
+                    exportKubeMenuItem.disable();
+                    deployToServerMenuItem.disable();
+                } else {
+                    exportMenuItem.enable();
+                    exportKubeMenuItem.enable();
+                    deployToServerMenuItem.enable();
+                }
             };
 
             this.openFileSaveDialog = function openFileSaveDialog(options) {


### PR DESCRIPTION
## Purpose
> Remove backend calls on keypress  
> Disable export when there are no files and deploy-to-server when there are no saved siddhi files.
> Fixes #540