### PR TITLE
Stop app runtime recreation when siddhi app is stopped

### DIFF
--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/DebugRuntime.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/DebugRuntime.java
@@ -138,10 +138,9 @@ public class DebugRuntime {
         }
         if (siddhiAppRuntime != null) {
             siddhiAppRuntime.shutdown();
-            siddhiAppRuntime = null;
+            mode = Mode.STOP;
         }
         callbackEventsQueue.clear();
-        createRuntime(siddhiApp);
     }
 
     public void reload(String siddhiApp) {


### PR DESCRIPTION
## Purpose
$subject fix https://github.com/siddhi-io/distribution/issues/771

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes