### PR TITLE
Enable support of dynamic runner default version image retrieval

### DIFF
--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
@@ -1336,6 +1336,22 @@ public class EditorMicroservice implements Microservice {
                 .build();
     }
 
+    @GET
+    @Path("/runnerDefaultDockerImage")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getRunnerDefaultDockerImage(@Context Request request) {
+        JsonObject dockerImageHolder = new JsonObject();
+        dockerImageHolder.addProperty(
+                "defaultRunnerDockerImage",
+                "siddhiio/siddhi-runner-alpine:" + EditorDataHolder.getBundleContext().getBundle().getVersion().toString()
+        );
+        return Response
+                .status(Response.Status.OK)
+                .entity(dockerImageHolder)
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
     /**
      * Get sample event for a particular event stream.
      *

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/EditorMicroservice.java
@@ -1343,7 +1343,8 @@ public class EditorMicroservice implements Microservice {
         JsonObject dockerImageHolder = new JsonObject();
         dockerImageHolder.addProperty(
                 "defaultRunnerDockerImage",
-                "siddhiio/siddhi-runner-alpine:" + EditorDataHolder.getBundleContext().getBundle().getVersion().toString()
+                "siddhiio/siddhi-runner-alpine:" +
+                        EditorDataHolder.getBundleContext().getBundle().getVersion().toString()
         );
         return Response
                 .status(Response.Status.OK)

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/ExportUtils.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/internal/ExportUtils.java
@@ -144,7 +144,8 @@ public class ExportUtils {
      * @return Zip archive file
      * @throws DockerGenerationException if docker generation fails
      */
-    public File createZipFile() throws DockerGenerationException, KubernetesGenerationException {
+    public File createZipFile()
+            throws DockerGenerationException, KubernetesGenerationException {
 
         boolean jarsAdded = false;
         boolean bundlesAdded = false;

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/editor/commons/js/dialog/export-dialog.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/editor/commons/js/dialog/export-dialog.js
@@ -55,6 +55,7 @@ define(['require', 'jquery', 'log', 'backbone', 'smart_wizard', 'siddhiAppSelect
                     this._dockerImageTypeModel;
                     this._exportUrl;
                     this._exportType;
+                    this._baseUrl;
                     this._isSkippedTemplateAppsStep = false;
                     this._isSkippedDockerConfigSteps = false;
 
@@ -63,6 +64,7 @@ define(['require', 'jquery', 'log', 'backbone', 'smart_wizard', 'siddhiAppSelect
                     } else {
                         this._exportType = 'kubernetes';
                     }
+                    this._baseUrl = options.config.baseUrl;
                     this._exportUrl = options.config.baseUrl + "/export?exportType=" + this._exportType;
                     this._btnExportForm =  $('' +
                         '<form id="submit-form" method="post" enctype="application/x-www-form-urlencoded" target="export-download" >' +
@@ -225,7 +227,8 @@ define(['require', 'jquery', 'log', 'backbone', 'smart_wizard', 'siddhiAppSelect
                             } else if (stepNumber === 4) {
                                 if (self._exportType === 'kubernetes') {
                                     self._dockerImageTypeModel = new DockerImageTypeDialog({
-                                    templateHeader: exportContainer.find('#docker-image-type-container-id'),
+                                        templateHeader: exportContainer.find('#docker-image-type-container-id'),
+                                        baseUrl: self._baseUrl,
                                     });
                                     self._dockerImageTypeModel.render();
                                 } else {

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/editor/js/export-deployment-artifacts/docker-image-type-dialog.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/editor/js/export-deployment-artifacts/docker-image-type-dialog.js
@@ -24,6 +24,7 @@ define(['require', 'lodash', 'jquery'],
             this.dockerNameInUpperError = options.templateHeader.find("#k8s-path-missing-docker-build-type-upper-error");
             this.templateContainer = options.templateHeader;
             this.dockerImageNameForm = options.templateHeader.find('#k8s-path-docker-image-name-form');
+            this.runnerDefaultDockerImageUrl = options.baseUrl + "/runnerDefaultDockerImage";
         };
 
         DockerImageTypeDialog.prototype.constructor = DockerImageTypeDialog;
@@ -38,7 +39,15 @@ define(['require', 'lodash', 'jquery'],
                     self.dockerImageNameForm.show();
                     self.templateContainer.find("#docker-image-type-tobuild").prop("checked", false);
                     if (self.dockerImageNameForm.find("#built-docker-image-name-input-field").val() == "") {
-                        self.dockerImageNameForm.find("#built-docker-image-name-input-field").val("siddhiio/siddhi-runner-alpine:5.1.2")
+                        var runnerDefaultDockerImage = "";
+                        $.ajax({
+                            url: self.runnerDefaultDockerImageUrl,
+                            success: function(dockerImageHolder) {
+                              runnerDefaultDockerImage = dockerImageHolder["defaultRunnerDockerImage"];
+                            },
+                            async:false
+                        });
+                        self.dockerImageNameForm.find("#built-docker-image-name-input-field").val(runnerDefaultDockerImage.toLowerCase());
                     }
                 } else {
                     self.dockerImageNameForm.hide();

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/editor/js/export-deployment-artifacts/kubernetes-config-dialog.js
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/resources/web/editor/js/export-deployment-artifacts/kubernetes-config-dialog.js
@@ -201,7 +201,7 @@ define(['require', 'lodash', 'jquery', 'log', 'ace/ace', 'app/source-editor/edit
                     messagingConfig = "\n" + messagingDefaultConfig;
                 }
                 if(self.pvConfigsGiven && editorObj.name == 'persistence') {
-                    pvConfig = "\n" + editorObj.content.session.getValue().toString();
+                    pvConfig = "\n" + editorObj.content.session.getValue().toString().trim();
                 }
                 if(self.statePersistenceConfigGiven && editorObj.name == 'state-persistence') {
                     statePersistenceConfig = "\n" + editorObj.content.session.getValue().toString().trim();


### PR DESCRIPTION
## Purpose
$subject

## Goals
Prevent from hardcoded Docker images with versions.

## Approach
Use a backend microservice to generate the default runner docker with version and return as a JSON.

## Related PRs
https://github.com/siddhi-io/distribution/pull/740

## Test environment
Java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)
Java HotSpot(TM) 64-Bit Server VM (build 25.201-b09, mixed mode)
Google Chrome Version 77.0.3865.90 (Official Build) (64-bit)