### PR TITLE
Remove log4j1 usage

### DIFF
--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/ConfigReaderTestCase.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/ConfigReaderTestCase.java
@@ -19,6 +19,8 @@ package io.siddhi.distribution.test.osgi;
 
 import io.siddhi.distribution.test.osgi.util.HTTPResponseMessage;
 import io.siddhi.distribution.test.osgi.util.TestUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.ExamFactory;
 import org.ops4j.pax.exam.Option;
@@ -46,7 +48,7 @@ import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFil
 @ExamReactorStrategy(PerClass.class)
 @ExamFactory(CarbonContainerFactory.class)
 public class ConfigReaderTestCase {
-    private static final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(ConfigReaderTestCase.class);
+    private static final Logger logger = LogManager.getLogger(ConfigReaderTestCase.class);
     private static final String DEFAULT_USER_NAME = "admin";
     private static final String DEFAULT_PASSWORD = "admin";
     private static final String CARBON_YAML_FILENAME = "deployment.yaml";

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/ConfigReaderTestCase2.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/ConfigReaderTestCase2.java
@@ -19,6 +19,8 @@ package io.siddhi.distribution.test.osgi;
 
 import io.siddhi.distribution.test.osgi.util.HTTPResponseMessage;
 import io.siddhi.distribution.test.osgi.util.TestUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.ExamFactory;
 import org.ops4j.pax.exam.Option;
@@ -46,7 +48,7 @@ import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFil
 @ExamReactorStrategy(PerClass.class)
 @ExamFactory(CarbonContainerFactory.class)
 public class ConfigReaderTestCase2 {
-    private static final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(ConfigReaderTestCase.class);
+    private static final Logger logger = LogManager.getLogger(ConfigReaderTestCase.class);
     private static final String DEFAULT_USER_NAME = "admin";
     private static final String DEFAULT_PASSWORD = "admin";
     private static final String CARBON_YAML_FILENAME = "deployment.yaml";

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/DBPersistenceStoreTestcase.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/DBPersistenceStoreTestcase.java
@@ -23,7 +23,8 @@ import io.siddhi.core.exception.CannotRestoreSiddhiAppStateException;
 import io.siddhi.distribution.core.internal.StreamProcessorDataHolder;
 import io.siddhi.distribution.test.osgi.util.RDBMSConfig;
 import io.siddhi.distribution.test.osgi.util.SiddhiAppUtil;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.awaitility.Awaitility;
 import org.awaitility.Duration;
 import org.ops4j.pax.exam.Configuration;
@@ -65,7 +66,7 @@ import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFil
 @ExamFactory(CarbonContainerFactory.class)
 public class DBPersistenceStoreTestcase {
 
-    private static final Logger log = Logger.getLogger(DBPersistenceStoreTestcase.class);
+    private static final Logger log = LogManager.getLogger(DBPersistenceStoreTestcase.class);
     private static final String CARBON_YAML_FILENAME = "deployment.yaml";
     private static final String TABLE_NAME = "PERSISTENCE_TABLE";
     private static final String SIDDHIAPP_NAME = "SiddhiAppPersistence";

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/FileSystemPersistenceStoreConfigTestcase.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/FileSystemPersistenceStoreConfigTestcase.java
@@ -20,7 +20,8 @@ import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.distribution.core.internal.StreamProcessorDataHolder;
 import io.siddhi.distribution.test.osgi.util.SiddhiAppUtil;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.awaitility.Awaitility;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.ExamFactory;
@@ -51,7 +52,7 @@ import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFil
 @ExamFactory(CarbonContainerFactory.class)
 public class FileSystemPersistenceStoreConfigTestcase {
 
-    private static final Logger log = Logger.getLogger(FileSystemPersistenceStoreConfigTestcase.class);
+    private static final Logger log = LogManager.getLogger(FileSystemPersistenceStoreConfigTestcase.class);
     static final String DEPLOYMENT_FILENAME = "deployment.yaml";
     private static final String PERSISTENCE_FOLDER = "siddhi-app-persistence";
     private static final String SIDDHIAPP_NAME = "SiddhiAppPersistence";

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/FileSystemPersistenceStoreTestcase.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/FileSystemPersistenceStoreTestcase.java
@@ -21,7 +21,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.exception.CannotRestoreSiddhiAppStateException;
 import io.siddhi.distribution.core.internal.StreamProcessorDataHolder;
 import io.siddhi.distribution.test.osgi.util.SiddhiAppUtil;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.awaitility.Awaitility;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.ExamFactory;
@@ -53,7 +54,7 @@ import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFil
 @ExamFactory(CarbonContainerFactory.class)
 public class FileSystemPersistenceStoreTestcase {
 
-    private static final Logger log = Logger.getLogger(FileSystemPersistenceStoreTestcase.class);
+    private static final Logger log = LogManager.getLogger(FileSystemPersistenceStoreTestcase.class);
     private static final String DEPLOYMENT_FILENAME = "deployment.yaml";
     private static final String PERSISTENCE_FOLDER = "siddhi-app-persistence";
     private static final String SIDDHIAPP_NAME = "SiddhiAppPersistence";

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/IncrementalDBPersistenceStoreTestcase.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/IncrementalDBPersistenceStoreTestcase.java
@@ -23,7 +23,8 @@ import io.siddhi.core.exception.CannotRestoreSiddhiAppStateException;
 import io.siddhi.distribution.core.internal.StreamProcessorDataHolder;
 import io.siddhi.distribution.test.osgi.util.RDBMSConfig;
 import io.siddhi.distribution.test.osgi.util.SiddhiAppUtil;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.awaitility.Awaitility;
 import org.awaitility.Duration;
 import org.ops4j.pax.exam.Configuration;
@@ -65,7 +66,7 @@ import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFil
 @ExamFactory(CarbonContainerFactory.class)
 public class IncrementalDBPersistenceStoreTestcase {
 
-    private static final Logger log = Logger.getLogger(IncrementalDBPersistenceStoreTestcase.class);
+    private static final Logger log = LogManager.getLogger(IncrementalDBPersistenceStoreTestcase.class);
     private static final String CARBON_YAML_FILENAME = "deployment.yaml";
     private static final String TABLE_NAME = "PERSISTENCE_TABLE";
     private static final String SIDDHIAPP_NAME = "SiddhiAppPersistence";

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/IncrementalFileSystemPersistenceStoreTestcase.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/IncrementalFileSystemPersistenceStoreTestcase.java
@@ -21,7 +21,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.exception.CannotRestoreSiddhiAppStateException;
 import io.siddhi.distribution.core.internal.StreamProcessorDataHolder;
 import io.siddhi.distribution.test.osgi.util.SiddhiAppUtil;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.awaitility.Awaitility;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.ExamFactory;
@@ -53,7 +54,7 @@ import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFil
 @ExamFactory(CarbonContainerFactory.class)
 public class IncrementalFileSystemPersistenceStoreTestcase {
 
-    private static final Logger log = Logger.getLogger(IncrementalFileSystemPersistenceStoreTestcase.class);
+    private static final Logger log = LogManager.getLogger(IncrementalFileSystemPersistenceStoreTestcase.class);
     private static final String DEPLOYMENT_FILENAME = "deployment.yaml";
     private static final String PERSISTENCE_FOLDER = "siddhi-app-persistence";
     private static final String SIDDHIAPP_NAME = "SiddhiAppPersistence";

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/SiddhiAsAPITestcase.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/SiddhiAsAPITestcase.java
@@ -20,6 +20,8 @@ import io.siddhi.distribution.common.common.EventStreamService;
 import io.siddhi.distribution.common.common.SiddhiAppRuntimeService;
 import io.siddhi.distribution.test.osgi.util.HTTPResponseMessage;
 import io.siddhi.distribution.test.osgi.util.TestUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.awaitility.Duration;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.ExamFactory;
@@ -49,7 +51,7 @@ import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFil
 @ExamReactorStrategy(PerClass.class)
 @ExamFactory(CarbonContainerFactory.class)
 public class SiddhiAsAPITestcase {
-    private static final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(SiddhiAsAPITestcase.class);
+    private static final Logger logger = LogManager.getLogger(SiddhiAsAPITestcase.class);
 
     private static final String DEFAULT_USER_NAME = "admin";
     private static final String DEFAULT_PASSWORD = "admin";

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/SiddhiMetricsTestcase.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/SiddhiMetricsTestcase.java
@@ -24,6 +24,8 @@ import io.siddhi.core.util.EventPrinter;
 import io.siddhi.core.util.SiddhiTestHelper;
 import io.siddhi.core.util.statistics.metrics.Level;
 import io.siddhi.distribution.common.common.SiddhiAppRuntimeService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.ExamFactory;
 import org.ops4j.pax.exam.Option;
@@ -60,7 +62,7 @@ import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFil
 @ExamReactorStrategy(PerClass.class)
 @ExamFactory(CarbonContainerFactory.class)
 public class SiddhiMetricsTestcase {
-    private static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(SiddhiMetricsTestcase.class);
+    private static final Logger log = LogManager.getLogger(SiddhiMetricsTestcase.class);
 
     private static final String LOAD_AVG_MBEAN_NAME = "org.wso2.carbon.metrics:name=jvm.os.system.load.average";
     private static final String SYSTEM_CPU_MBEAN_NAME = "org.wso2.carbon.metrics:name=jvm.os.cpu.load.system";

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/SiddhiStoreAPITestcase.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/SiddhiStoreAPITestcase.java
@@ -29,6 +29,8 @@ import io.siddhi.distribution.store.api.rest.rest.model.Query;
 import io.siddhi.distribution.test.osgi.util.HTTPResponseMessage;
 import io.siddhi.distribution.test.osgi.util.TestConstants;
 import io.siddhi.distribution.test.osgi.util.TestUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.awaitility.Duration;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.ExamFactory;
@@ -62,7 +64,7 @@ import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFil
 @ExamReactorStrategy(PerClass.class)
 @ExamFactory(CarbonContainerFactory.class)
 public class SiddhiStoreAPITestcase {
-    private static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(SiddhiStoreAPITestcase.class);
+    private static final Logger log = LogManager.getLogger(SiddhiStoreAPITestcase.class);
     private static final String APP_NAME = "StoreApiTest";
     private static final String SIDDHI_EXTENSION = ".siddhi";
     private static final String STORE_API_BUNDLE_NAME = "io.siddhi.distribution.store.api.rest";

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/SiddhiToolingTestCase.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/SiddhiToolingTestCase.java
@@ -20,6 +20,8 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import io.siddhi.distribution.test.osgi.util.HTTPResponseMessage;
 import io.siddhi.distribution.test.osgi.util.TestUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.ExamFactory;
 import org.ops4j.pax.exam.Option;
@@ -50,7 +52,7 @@ import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFil
 @ExamReactorStrategy(PerClass.class)
 @ExamFactory(CarbonContainerFactory.class)
 public class SiddhiToolingTestCase {
-    private static final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(
+    private static final Logger logger = LogManager.getLogger(
             SiddhiToolingTestCase.class);
 
     private static final String DEFAULT_USER_NAME = "admin";

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/SimulatorAPITestcase.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/SimulatorAPITestcase.java
@@ -17,6 +17,8 @@ package io.siddhi.distribution.test.osgi;
 
 import io.siddhi.distribution.test.osgi.util.HTTPResponseMessage;
 import io.siddhi.distribution.test.osgi.util.TestUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.ExamFactory;
 import org.ops4j.pax.exam.Option;
@@ -46,7 +48,7 @@ import static org.wso2.carbon.container.options.CarbonDistributionOption.copyFil
 @ExamReactorStrategy(PerClass.class)
 @ExamFactory(CarbonContainerFactory.class)
 public class SimulatorAPITestcase {
-    private static final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(SimulatorAPITestcase.class);
+    private static final Logger logger = LogManager.getLogger(SimulatorAPITestcase.class);
 
     private static final int HTTP_PORT = 9390;
     private static final String HOSTNAME = "localhost";

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/util/KafkaTestUtil.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/util/KafkaTestUtil.java
@@ -29,7 +29,8 @@ import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.ZkConnection;
 import org.apache.commons.io.FileUtils;
 import org.apache.curator.test.TestingServer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -39,7 +40,7 @@ import java.util.Properties;
  * Kafka test util.
  */
 public class KafkaTestUtil {
-    private static final Logger log = Logger.getLogger(KafkaTestUtil.class);
+    private static final Logger log = LogManager.getLogger(KafkaTestUtil.class);
     private static final String kafkaLogDir = "tmp_kafka_dir";
     private static final long CLEANER_BUFFER_SIZE = 2 * 1024 * 1024L;
     private static TestingServer zkTestServer;

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/util/RDBMSConfig.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/util/RDBMSConfig.java
@@ -18,7 +18,8 @@ package io.siddhi.distribution.test.osgi.util;
 
 import io.siddhi.distribution.test.osgi.DBPersistenceStoreTestcase;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -34,7 +35,7 @@ import java.net.URISyntaxException;
  */
 public class RDBMSConfig {
 
-    private static final Logger log = Logger.getLogger(RDBMSConfig.class);
+    private static final Logger log = LogManager.getLogger(RDBMSConfig.class);
     private static final String YAML_DATASOURCE_CONFIG_JDBC_URL = "          jdbcUrl:";
     private static final String YAML_DATASOURCE_CONFIG_USERNAME = "          username:";
     private static final String YAML_DATASOURCE_CONFIG_PASSWORD = "          password:";

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/util/SiddhiAppUtil.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/util/SiddhiAppUtil.java
@@ -22,7 +22,8 @@ import io.siddhi.core.event.Event;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.stream.output.StreamCallback;
 import io.siddhi.core.util.EventPrinter;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +33,7 @@ import java.util.List;
  */
 public class SiddhiAppUtil {
 
-    private static final Logger log = Logger.getLogger(SiddhiAppUtil.class);
+    private static final Logger log = LogManager.getLogger(SiddhiAppUtil.class);
 
     private static final String SIDDHIAPP_STREAM = "@App:name('SiddhiAppPersistence')" +
             "define stream FooStream (symbol string, volume long); ";

--- a/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/util/TestUtil.java
+++ b/osgi-tests/src/test/java/io/siddhi/distribution/test/osgi/util/TestUtil.java
@@ -20,6 +20,8 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.distribution.common.common.EventStreamService;
 import io.siddhi.distribution.common.common.SiddhiAppRuntimeService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.awaitility.Duration;
 import org.wso2.msf4j.MicroservicesRegistry;
 
@@ -50,7 +52,7 @@ import static java.net.URLConnection.guessContentTypeFromName;
 public class TestUtil {
     private static final String LINE_FEED = "\r\n";
     private static final String CHARSET = "UTF-8";
-    private static final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(TestUtil.class);
+    private static final Logger logger = LogManager.getLogger(TestUtil.class);
     private HttpURLConnection connection = null;
     private OutputStream outputStream = null;
     private PrintWriter writer = null;

--- a/pom.xml
+++ b/pom.xml
@@ -517,9 +517,27 @@
                 <version>${findbugs.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.log4j.wso2</groupId>
-                <artifactId>log4j</artifactId>
-                <version>${log4j.wso2.version}</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.mail</groupId>
+                        <artifactId>mail</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.jms</groupId>
+                        <artifactId>jms</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.sun.jdmk</groupId>
+                        <artifactId>jmxtools</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.sun.jmx</groupId>
+                        <artifactId>jmxri</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- Swagger Documentation dependencies -->
             <dependency>
@@ -1223,10 +1241,10 @@
     </dependencyManagement>
 
     <properties>
-        <siddhi.version>5.1.12</siddhi.version>
-        <siddhi.bundle.version>5.1.12</siddhi.bundle.version>
+        <siddhi.version>5.1.21</siddhi.version>
+        <siddhi.bundle.version>5.1.21</siddhi.bundle.version>
         <siddhi.version.range>[5.0.0, 6.0.0)</siddhi.version.range>
-        <carbon.analytics-common.version>6.1.40</carbon.analytics-common.version>
+        <carbon.analytics-common.version>6.1.57</carbon.analytics-common.version>
         <carbon.analytics-common.version.range>[6.1.0, 6.2.0)</carbon.analytics-common.version.range>
         <io.siddhi.distribution.version.range>[5.0.0, 6.0.0)</io.siddhi.distribution.version.range>
 
@@ -1275,8 +1293,8 @@
         <commons-lang3.version>3.9</commons-lang3.version>
         <kafka-2.11.version>0.10.0.0</kafka-2.11.version>
         <httpclient.version>4.3.6.wso2v2</httpclient.version>
-        <pax.logging.log4j2.version>1.11.2</pax.logging.log4j2.version>
-        <log4j.wso2.version>1.2.17.wso2v1</log4j.wso2.version>
+        <pax.logging.log4j2.version>2.1.0</pax.logging.log4j2.version>
+        <log4j.version>2.17.1</log4j.version>
         <pax.exam.container.native.version>4.13.1</pax.exam.container.native.version>
         <pax.url.aether.version>2.6.1</pax.url.aether.version>
         <org.jacoco.ant.version>0.8.5</org.jacoco.ant.version>
@@ -1311,7 +1329,7 @@
         <com.fasterxml.jackson.core.version>2.9.10</com.fasterxml.jackson.core.version>
         <io.swagger.version>1.6.0</io.swagger.version>
         <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
-        <pax.logging.api.version>1.11.2</pax.logging.api.version>
+        <pax.logging.api.version>2.1.0</pax.logging.api.version>
         <javax.servlet.version>4.0.1</javax.servlet.version>
         <javax.annotation.version>1.3.2</javax.annotation.version>
         <javax.websocket.api.version>1.1</javax.websocket.api.version>

--- a/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/config/FileConfigReader.java
+++ b/runner/components/io.siddhi.distribution.common/src/main/java/io/siddhi/distribution/common/common/utils/config/FileConfigReader.java
@@ -18,7 +18,8 @@
 package io.siddhi.distribution.common.common.utils.config;
 
 import io.siddhi.core.util.config.ConfigReader;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,7 +28,7 @@ import java.util.Map;
  * Siddhi file configuration reader.
  */
 public class FileConfigReader implements ConfigReader {
-    static final Logger LOGGER = Logger.getLogger(FileConfigReader.class);
+    private static final Logger LOGGER = LogManager.getLogger(FileConfigReader.class);
     Map<String, String> propertyMap;
 
     public FileConfigReader(Map<String, String> propertyMap) {

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/DBPersistenceStore.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/DBPersistenceStore.java
@@ -29,7 +29,8 @@ import io.siddhi.distribution.core.persistence.util.DBPersistenceStoreUtils;
 import io.siddhi.distribution.core.persistence.util.ExecutionInfo;
 import io.siddhi.distribution.core.persistence.util.PersistenceConstants;
 import io.siddhi.distribution.core.persistence.util.RDBMSConfiguration;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.datasource.core.exception.DataSourceException;
 
 import java.io.IOException;
@@ -49,7 +50,7 @@ import javax.sql.rowset.serial.SerialBlob;
  */
 public class DBPersistenceStore implements PersistenceStore {
 
-    private static final Logger log = Logger.getLogger(DBPersistenceStore.class);
+    private static final Logger log = LogManager.getLogger(DBPersistenceStore.class);
     private static final String MSSQL_DATABASE_TYPE = "microsoft sql server";
     private static final String POSTGRES_DATABASE_TYPE = "postgresql";
 

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/FileSystemPersistenceStore.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/FileSystemPersistenceStore.java
@@ -23,7 +23,8 @@ import io.siddhi.core.exception.CannotClearSiddhiAppStateException;
 import io.siddhi.core.util.persistence.PersistenceStore;
 import io.siddhi.distribution.core.impl.utils.CompressionUtil;
 import io.siddhi.distribution.core.persistence.util.PersistenceConstants;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,7 +35,7 @@ import java.util.Map;
  */
 public class FileSystemPersistenceStore implements PersistenceStore {
 
-    private static final Logger log = Logger.getLogger(FileSystemPersistenceStore.class);
+    private static final Logger log = LogManager.getLogger(FileSystemPersistenceStore.class);
     private int numberOfRevisionsToSave;
     private String folder;
 

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/GCSPersistenceStore.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/GCSPersistenceStore.java
@@ -30,7 +30,8 @@ import io.siddhi.core.util.persistence.PersistenceStore;
 import io.siddhi.distribution.core.impl.utils.CompressionUtil;
 import io.siddhi.distribution.core.persistence.exception.GCSPersistenceStoreException;
 import io.siddhi.distribution.core.persistence.util.PersistenceConstants;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -44,7 +45,7 @@ import java.util.Queue;
  * Implementation of Persistence Store that would persist snapshots to the GCS.
  */
 public class GCSPersistenceStore implements PersistenceStore {
-    private static Logger log = Logger.getLogger(GCSPersistenceStore.class);
+    private static Logger log = LogManager.getLogger(GCSPersistenceStore.class);
     private Storage storage;
     private String bucketName;
     private int numberOfRevisionsToSave;

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/IncrementalDBPersistenceStore.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/IncrementalDBPersistenceStore.java
@@ -31,7 +31,8 @@ import io.siddhi.distribution.core.persistence.util.DBPersistenceStoreUtils;
 import io.siddhi.distribution.core.persistence.util.ExecutionInfo;
 import io.siddhi.distribution.core.persistence.util.PersistenceConstants;
 import io.siddhi.distribution.core.persistence.util.RDBMSConfiguration;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.datasource.core.exception.DataSourceException;
 
 import java.io.IOException;
@@ -52,7 +53,7 @@ import javax.sql.rowset.serial.SerialBlob;
  * Implementation class of DB based persistence store.
  */
 public class IncrementalDBPersistenceStore implements IncrementalPersistenceStore {
-    private static final Logger log = Logger.getLogger(IncrementalDBPersistenceStore.class);
+    private static final Logger log = LogManager.getLogger(IncrementalDBPersistenceStore.class);
 
     private static final String MSSQL_DATABASE_TYPE = "microsoft sql server";
     private static final String POSTGRES_DATABASE_TYPE = "postgresql";

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/IncrementalFileSystemPersistenceStore.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/IncrementalFileSystemPersistenceStore.java
@@ -25,7 +25,8 @@ import io.siddhi.core.util.persistence.util.IncrementalSnapshotInfo;
 import io.siddhi.core.util.persistence.util.PersistenceHelper;
 import io.siddhi.distribution.core.impl.utils.CompressionUtil;
 import io.siddhi.distribution.core.persistence.util.PersistenceConstants;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,7 +39,7 @@ import java.util.Map;
  */
 public class IncrementalFileSystemPersistenceStore implements IncrementalPersistenceStore {
 
-    private static final Logger log = Logger.getLogger(IncrementalFileSystemPersistenceStore.class);
+    private static final Logger log = LogManager.getLogger(IncrementalFileSystemPersistenceStore.class);
     private String folder;
 
     public IncrementalFileSystemPersistenceStore() {

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/S3PersistenceStore.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/S3PersistenceStore.java
@@ -23,7 +23,8 @@ import io.siddhi.core.util.persistence.PersistenceStore;
 import io.siddhi.distribution.core.impl.utils.CompressionUtil;
 import io.siddhi.distribution.core.persistence.exception.S3PersistenceStoreException;
 import io.siddhi.distribution.core.persistence.util.PersistenceConstants;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -57,7 +58,7 @@ import java.util.Map;
  * Implementation of Persistence Store that would persist snapshots to the s3 bucket.
  */
 public class S3PersistenceStore implements PersistenceStore {
-    private static final Logger log = Logger.getLogger(S3PersistenceStore.class);
+    private static final Logger log = LogManager.getLogger(S3PersistenceStore.class);
     private S3Client s3Client;
     private String bucketName;
     private int numberOfRevisionsToSave;

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/util/DBPersistenceStoreUtils.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/util/DBPersistenceStoreUtils.java
@@ -18,7 +18,8 @@
 
 package io.siddhi.distribution.core.persistence.util;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -30,7 +31,7 @@ import javax.sql.DataSource;
  * Util class for DB persistence store.
  */
 public class DBPersistenceStoreUtils {
-    private static final Logger log = Logger.getLogger(DBPersistenceStoreUtils.class);
+    private static final Logger log = LogManager.getLogger(DBPersistenceStoreUtils.class);
 
     /**
      * Method that would create the persistence table.

--- a/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/util/RDBMSConfiguration.java
+++ b/runner/components/io.siddhi.distribution.core/src/main/java/io/siddhi/distribution/core/persistence/util/RDBMSConfiguration.java
@@ -22,7 +22,6 @@ import io.siddhi.distribution.core.internal.StreamProcessorDataHolder;
 import io.siddhi.distribution.core.persistence.dto.RDBMSQueryConfigurationEntry;
 import io.siddhi.distribution.core.persistence.exception.DatasourceConfigurationException;
 import io.siddhi.distribution.core.persistence.query.QueryManager;
-import org.apache.log4j.Logger;
 import org.wso2.carbon.config.ConfigurationException;
 import org.wso2.carbon.database.query.manager.exception.QueryMappingNotAvailableException;
 
@@ -33,7 +32,6 @@ import java.io.IOException;
  */
 public class RDBMSConfiguration {
 
-    private static final Logger log = Logger.getLogger(RDBMSConfiguration.class);
     private static RDBMSConfiguration config = new RDBMSConfiguration();
 
     private RDBMSConfiguration() {

--- a/runner/components/io.siddhi.distribution.core/src/test/java/io/siddhi/distribution/core/DBPersistenceStoreTest.java
+++ b/runner/components/io.siddhi.distribution.core/src/test/java/io/siddhi/distribution/core/DBPersistenceStoreTest.java
@@ -21,11 +21,8 @@ import io.siddhi.distribution.core.internal.StreamProcessorDataHolder;
 import io.siddhi.distribution.core.persistence.DBPersistenceStore;
 import io.siddhi.distribution.core.persistence.exception.DatasourceConfigurationException;
 import io.siddhi.distribution.core.persistence.util.PersistenceConstants;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import org.wso2.carbon.datasource.core.exception.DataSourceException;
 import org.wso2.carbon.datasource.core.impl.DataSourceServiceImpl;
@@ -44,11 +41,6 @@ import static org.powermock.api.mockito.PowerMockito.when;
  */
 @PrepareForTest(StreamProcessorDataHolder.class)
 public class DBPersistenceStoreTest extends PowerMockTestCase {
-
-    @BeforeTest
-    public void setDebugLogLevel() {
-        Logger.getLogger(DBPersistenceStore.class.getName()).setLevel(Level.DEBUG);
-    }
 
     @Test(expectedExceptions = DatasourceConfigurationException.class)
     public void testDataSourceConfigurationException() {

--- a/runner/components/io.siddhi.distribution.core/src/test/java/io/siddhi/distribution/core/DynamicHtmlGenTest.java
+++ b/runner/components/io.siddhi.distribution.core/src/test/java/io/siddhi/distribution/core/DynamicHtmlGenTest.java
@@ -17,8 +17,9 @@
 package io.siddhi.distribution.core;
 
 import io.siddhi.distribution.core.codegen.DynamicHtmlGen;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -30,7 +31,8 @@ public class DynamicHtmlGenTest {
 
     @BeforeTest
     public void setDebugLogLevel() {
-        Logger.getLogger(DynamicHtmlGenTest.class.getName()).setLevel(Level.DEBUG);
+        Logger logger = (Logger) LogManager.getLogger(DynamicHtmlGenTest.class.getName());
+        logger.setLevel(Level.DEBUG);
     }
 
     @Test

--- a/runner/components/io.siddhi.distribution.core/src/test/java/io/siddhi/distribution/core/util/UnitTestAppender.java
+++ b/runner/components/io.siddhi.distribution.core/src/test/java/io/siddhi/distribution/core/util/UnitTestAppender.java
@@ -17,8 +17,15 @@
  */
 package io.siddhi.distribution.core.util;
 
-import org.apache.log4j.AppenderSkeleton;
-import org.apache.log4j.spi.LoggingEvent;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Core;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,24 +33,38 @@ import java.util.List;
 /**
  * Util class to read the logs of test cases.
  */
-public class UnitTestAppender extends AppenderSkeleton {
+@Plugin(name = "UnitTestAppender",
+        category = Core.CATEGORY_NAME, elementType = Appender.ELEMENT_TYPE)
+public class UnitTestAppender extends AbstractAppender {
+
     private List<String> messages = new ArrayList<>();
 
-    @Override
-    protected void append(LoggingEvent loggingEvent) {
-        messages.add(loggingEvent.getRenderedMessage());
+    public UnitTestAppender(String name, Filter filter) {
+
+        super(name, filter, null);
+    }
+
+    @PluginFactory
+    public static UnitTestAppender createAppender(
+            @PluginAttribute("name") String name,
+            @PluginElement("Filter") Filter filter) {
+
+        return new UnitTestAppender(name, filter);
+    }
+
+    public String getMessages() {
+
+        String results = messages.toString();
+        if (results.isEmpty()) {
+            return null;
+        }
+        return results;
     }
 
     @Override
-    public void close() {
+    public void append(LogEvent event) {
+        messages.add(event.getMessage().getFormattedMessage());
     }
 
-    @Override
-    public boolean requiresLayout() {
-        return false;
-    }
-
-    public List<String> getMessages() {
-        return messages;
-    }
 }
+

--- a/runner/components/io.siddhi.distribution.core/src/test/resources/log4j2.xml
+++ b/runner/components/io.siddhi.distribution.core/src/test/resources/log4j2.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ /*
+  ~  * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~  *
+  ~  * WSO2 Inc. licenses this file to you under the Apache License,
+  ~  * Version 2.0 (the "License"); you may not use this file except
+  ~  * in compliance with the License.
+  ~  * You may obtain a copy of the License at
+  ~  *
+  ~  *     http://www.apache.org/licenses/LICENSE-2.0
+  ~  *
+  ~  * Unless required by applicable law or agreed to in writing,
+  ~  * software distributed under the License is distributed on an
+  ~  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  * KIND, either express or implied. See the License for the
+  ~  * specific language governing permissions and limitations
+  ~  * under the License.
+  ~  */
+  -->
+
+<Configuration status="WARN" packages="io.siddhi.distribution.core" >
+    <Appenders>
+        <Console name="ConsoleAppender" target="SYSTEM_OUT"/>
+        <UnitTestAppender name="UnitTestAppender"/>
+    </Appenders>
+    <Loggers>
+        <Root level="DEBUG">
+            <AppenderRef ref="ConsoleAppender" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/runner/components/io.siddhi.distribution.metrics.core/src/main/java/io/siddhi/distribution/metrics/prometheus/reporter/impl/PrometheusReporter.java
+++ b/runner/components/io.siddhi.distribution.metrics.core/src/main/java/io/siddhi/distribution/metrics/prometheus/reporter/impl/PrometheusReporter.java
@@ -26,7 +26,8 @@ import io.prometheus.client.dropwizard.samplebuilder.CustomMappingSampleBuilder;
 import io.prometheus.client.dropwizard.samplebuilder.MapperConfig;
 import io.prometheus.client.dropwizard.samplebuilder.SampleBuilder;
 import io.prometheus.client.exporter.HTTPServer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.metrics.core.reporter.impl.AbstractReporter;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
@@ -46,7 +47,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class PrometheusReporter extends AbstractReporter {
 
-    private static final Logger log = Logger.getLogger(PrometheusReporter.class);
+    private static final Logger log = LogManager.getLogger(PrometheusReporter.class);
     private static final String MAPPINGS_RESOURCE_FILE = "configuration.yaml";
     private final MetricRegistry metricRegistry;
     private final MetricFilter metricFilter;

--- a/runner/components/io.siddhi.distribution.metrics.core/src/test/java/io/siddhi/distribution/metrics/core/StatisticsTestCase.java
+++ b/runner/components/io.siddhi.distribution.metrics.core/src/test/java/io/siddhi/distribution/metrics/core/StatisticsTestCase.java
@@ -28,7 +28,8 @@ import io.siddhi.core.util.EventPrinter;
 import io.siddhi.core.util.statistics.EventBufferHolder;
 import io.siddhi.distribution.metrics.core.internal.SiddhiMetricsDataHolder;
 import io.siddhi.distribution.metrics.core.internal.SiddhiStatisticsManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
@@ -47,7 +48,7 @@ import java.util.concurrent.TimeUnit;
  * Test case for carbon metrics inside siddhi.
  */
 public class StatisticsTestCase {
-    private static final Logger log = Logger.getLogger(StatisticsTestCase.class);
+    private static final Logger log = LogManager.getLogger(StatisticsTestCase.class);
     protected static Metrics metrics;
     protected static MetricService metricService;
     protected static MetricManagementService metricManagementService;

--- a/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/appcreator/NatsSiddhiAppCreator.java
+++ b/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/appcreator/NatsSiddhiAppCreator.java
@@ -25,7 +25,8 @@ import io.siddhi.parser.core.topology.SubscriptionStrategyDataHolder;
 import io.siddhi.parser.core.util.TransportStrategy;
 import io.siddhi.parser.service.model.MessagingSystem;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,7 +39,7 @@ import java.util.Map;
  */
 public class NatsSiddhiAppCreator extends AbstractSiddhiAppCreator {
 
-    private static final Logger log = Logger.getLogger(NatsSiddhiAppCreator.class);
+    private static final Logger log = LogManager.getLogger(NatsSiddhiAppCreator.class);
     //App creator constants
     public static final String APP_NAME = "appName";
     public static final String TOPIC_LIST = "topicList";

--- a/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/topology/SiddhiTopologyCreatorImpl.java
+++ b/runner/components/io.siddhi.parser/src/main/java/io/siddhi/parser/core/topology/SiddhiTopologyCreatorImpl.java
@@ -48,7 +48,8 @@ import io.siddhi.query.api.util.AnnotationHelper;
 import io.siddhi.query.api.util.ExceptionUtil;
 import io.siddhi.query.compiler.SiddhiCompiler;
 import org.apache.commons.lang3.text.StrSubstitutor;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -69,7 +70,7 @@ import static io.siddhi.parser.core.util.SiddhiTopologyCreatorConstants.INMEMORY
 
 public class SiddhiTopologyCreatorImpl implements SiddhiTopologyCreator {
 
-    private static final Logger log = Logger.getLogger(SiddhiTopologyCreatorImpl.class);
+    private static final Logger log = LogManager.getLogger(SiddhiTopologyCreatorImpl.class);
     private static final String DEFAULT_MESSAGING_SYSTEM = "nats";
     private SiddhiTopologyDataHolder siddhiTopologyDataHolder;
     private SiddhiApp siddhiApp;

--- a/runner/components/io.siddhi.parser/src/test/java/io/siddhi/parser/NatsAppCreatorTestCase.java
+++ b/runner/components/io.siddhi.parser/src/test/java/io/siddhi/parser/NatsAppCreatorTestCase.java
@@ -30,7 +30,6 @@ import io.siddhi.parser.core.topology.SiddhiTopology;
 import io.siddhi.parser.core.topology.SiddhiTopologyCreatorImpl;
 import io.siddhi.parser.service.model.MessagingConfig;
 import io.siddhi.parser.service.model.MessagingSystem;
-import org.apache.log4j.Logger;
 import org.testcontainers.containers.GenericContainer;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -43,7 +42,6 @@ import java.util.List;
  */
 public class NatsAppCreatorTestCase {
 
-    private static final Logger log = Logger.getLogger(NatsAppCreatorTestCase.class);
     private static final String CLUSTER_ID = "test-cluster";
     private static String NATS_SERVER_URL = "nats://localhost:4222";
     private int port;

--- a/samples/sample-clients/grpc-client/src/main/java/io/siddhi/distribution/sample/grpc/client/GrpcClient.java
+++ b/samples/sample-clients/grpc-client/src/main/java/io/siddhi/distribution/sample/grpc/client/GrpcClient.java
@@ -20,7 +20,8 @@ package io.siddhi.distribution.sample.grpc.client;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.grpc.Event;
 import org.wso2.grpc.EventServiceGrpc;
 
@@ -30,7 +31,7 @@ import java.util.Arrays;
  * This is a sample gRpc client to publish events to gRpc endpoint.
  */
 public class GrpcClient {
-    private static final Logger log = Logger.getLogger(GrpcClient.class);
+    private static final Logger log = LogManager.getLogger(GrpcClient.class);
 
     /**
      * Main method to start the test client.

--- a/samples/sample-clients/grpc-generic-client/src/main/java/io/siddhi/distribution/sample/grpc/generic/client/GrpcGenericClient.java
+++ b/samples/sample-clients/grpc-generic-client/src/main/java/io/siddhi/distribution/sample/grpc/generic/client/GrpcGenericClient.java
@@ -22,7 +22,8 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.siddhi.distribution.sample.grpc.Sweet;
 import io.siddhi.distribution.sample.grpc.SweetServiceGrpc;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +32,7 @@ import java.util.List;
  * This is a sample generic gRPC client to publish events to gRPC endpoint.
  */
 public class GrpcGenericClient {
-    private static final Logger log = Logger.getLogger(GrpcGenericClient.class);
+    private static final Logger log = LogManager.getLogger(GrpcGenericClient.class);
     private static List<SweetProduct> listOfSweets = new ArrayList<>();
 
     /**

--- a/samples/sample-clients/grpc-generic-server/src/main/java/io/siddhi/distribution/sample/grpc/generic/server/GenericServer.java
+++ b/samples/sample-clients/grpc-generic-server/src/main/java/io/siddhi/distribution/sample/grpc/generic/server/GenericServer.java
@@ -23,7 +23,8 @@ import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import io.siddhi.distribution.sample.grpc.Sweet;
 import io.siddhi.distribution.sample.grpc.SweetServiceGrpc;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 
@@ -31,7 +32,7 @@ import java.io.IOException;
  * Test Grpc Generic server
  */
 public class GenericServer {
-    private static final Logger logger = Logger.getLogger(GenericServer.class.getName());
+    private static final Logger logger = LogManager.getLogger(GenericServer.class.getName());
     private Server server;
     private int port;
 

--- a/samples/sample-clients/grpc-server/src/main/java/io/siddhi/distribution/sample/grpc/server/Server.java
+++ b/samples/sample-clients/grpc-server/src/main/java/io/siddhi/distribution/sample/grpc/server/Server.java
@@ -20,7 +20,8 @@ package io.siddhi.distribution.sample.grpc.server;
 import io.grpc.BindableService;
 import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 import org.wso2.grpc.Event;
 import org.wso2.grpc.EventServiceGrpc;
@@ -31,7 +32,7 @@ import java.io.IOException;
  * GRPC service class
  */
 public class Server {
-    private static final Logger logger = Logger.getLogger(Server.class.getName());
+    private static final Logger logger = LogManager.getLogger(Server.class.getName());
     private io.grpc.Server server;
     private int port;
 

--- a/samples/sample-clients/http-client/src/main/java/io/siddhi/distribution/sample/http/client/EventSendingUtil.java
+++ b/samples/sample-clients/http-client/src/main/java/io/siddhi/distribution/sample/http/client/EventSendingUtil.java
@@ -19,7 +19,8 @@
 package io.siddhi.distribution.sample.http.client;
 
 import io.siddhi.core.stream.input.InputHandler;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,7 +32,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * Event generating util class for http source.
  */
 public class EventSendingUtil {
-    private static final Logger log = Logger.getLogger(EventSendingUtil.class);
+    private static final Logger log = LogManager.getLogger(EventSendingUtil.class);
     public static void publishEvents(List<String[]> fileEntriesList, boolean sendEventsContinuously,
                                      int noOfEventsToSend, String eventDefinition, String[] sweetName,
                                      InputHandler inputHandler, int delay, boolean isBinaryMessage,

--- a/samples/sample-clients/http-client/src/main/java/io/siddhi/distribution/sample/http/client/HttpClient.java
+++ b/samples/sample-clients/http-client/src/main/java/io/siddhi/distribution/sample/http/client/HttpClient.java
@@ -21,7 +21,8 @@ package io.siddhi.distribution.sample.http.client;
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.stream.input.InputHandler;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,7 +35,7 @@ import java.util.Scanner;
  * This is a sample HTTP client to publish events to HTTP/HTTPS endpoint.
  */
 public class HttpClient {
-    private static final Logger log = Logger.getLogger(HttpClient.class);
+    private static final Logger log = LogManager.getLogger(HttpClient.class);
     private static final String EMPTY_STRING = "EMPTY";
 
     /**

--- a/samples/sample-clients/http-server/src/main/java/io/siddhi/distribution/sample/http/server/HttpServerListener.java
+++ b/samples/sample-clients/http-server/src/main/java/io/siddhi/distribution/sample/http/server/HttpServerListener.java
@@ -21,7 +21,8 @@ package io.siddhi.distribution.sample.http.server;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -34,7 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Test Server Listener Manger.
  */
 public class HttpServerListener implements HttpHandler {
-    private static final Logger logger = Logger.getLogger(HttpServerListener.class);
+    private static final Logger logger = LogManager.getLogger(HttpServerListener.class);
     private AtomicBoolean isEventArraved = new AtomicBoolean(false);
     private StringBuilder strBld = new StringBuilder();
     private Headers headers;

--- a/samples/sample-clients/http-server/src/main/java/io/siddhi/distribution/sample/http/server/HttpServerListenerHandler.java
+++ b/samples/sample-clients/http-server/src/main/java/io/siddhi/distribution/sample/http/server/HttpServerListenerHandler.java
@@ -19,7 +19,8 @@
 package io.siddhi.distribution.sample.http.server;
 
 import com.sun.net.httpserver.HttpServer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -32,7 +33,7 @@ public class HttpServerListenerHandler {
         return sl;
     }
 
-    private static final Logger logger = Logger.getLogger(HttpServerListenerHandler.class);
+    private static final Logger logger = LogManager.getLogger(HttpServerListenerHandler.class);
     private HttpServerListener sl;
     private HttpServer server;
     private int port;

--- a/samples/sample-clients/http-server/src/main/java/io/siddhi/distribution/sample/http/server/HttpServerMain.java
+++ b/samples/sample-clients/http-server/src/main/java/io/siddhi/distribution/sample/http/server/HttpServerMain.java
@@ -23,7 +23,6 @@ package io.siddhi.distribution.sample.http.server;
  * This is a sample HTTP server to receive events through HTTP/HTTPS protocol.
  */
 public class HttpServerMain {
-    private static final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(HttpServerMain.class);
 
     public static void main(String[] args) throws InterruptedException {
         HttpServerListenerHandler lst = new HttpServerListenerHandler(8080);

--- a/samples/sample-clients/http-server/src/main/java/io/siddhi/distribution/sample/http/server/HttpsServerListenerHandler.java
+++ b/samples/sample-clients/http-server/src/main/java/io/siddhi/distribution/sample/http/server/HttpsServerListenerHandler.java
@@ -21,7 +21,8 @@ package io.siddhi.distribution.sample.http.server;
 import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsParameters;
 import com.sun.net.httpserver.HttpsServer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -32,7 +33,6 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
-
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
@@ -42,7 +42,7 @@ import javax.net.ssl.TrustManagerFactory;
  * Https test sever listener.
  */
 public class HttpsServerListenerHandler {
-    private static final Logger logger = Logger.getLogger(HttpsServerListenerHandler.class);
+    private static final Logger logger = LogManager.getLogger(HttpsServerListenerHandler.class);
     private HttpServerListener sl;
     private int port;
     private KeyStore ks;

--- a/samples/sample-clients/jms-consumer/src/main/java/org/wso2/sp/sample/jms/consumer/JmsReceiver.java
+++ b/samples/sample-clients/jms-consumer/src/main/java/org/wso2/sp/sample/jms/consumer/JmsReceiver.java
@@ -20,13 +20,14 @@ package org.wso2.sp.sample.jms.consumer;
 
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Test client for Jms source.
  */
 public class JmsReceiver {
-    private static final Logger log = Logger.getLogger(JmsReceiver.class);
+    private static final Logger log = LogManager.getLogger(JmsReceiver.class);
 
     /**
      * Main method to start the test client.

--- a/samples/sample-clients/jms-producer/src/main/java/io/siddhi/distribution/sample/jms/client/JmsClient.java
+++ b/samples/sample-clients/jms-producer/src/main/java/io/siddhi/distribution/sample/jms/client/JmsClient.java
@@ -21,7 +21,8 @@ package io.siddhi.distribution.sample.jms.client;
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.stream.input.InputHandler;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,7 +36,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * This is a sample JMS client to publish events to JMS endpoint.
  */
 public class JmsClient {
-    private static final Logger log = Logger.getLogger(JmsClient.class);
+    private static final Logger log = LogManager.getLogger(JmsClient.class);
     private static final String EMPTY_STRING = "EMPTY";
 
     public static void main(String[] args) throws IOException, InterruptedException {

--- a/samples/sample-clients/kafka-avro-consumer/src/main/java/io/siddhi/distribution/sample/kafka/avro/consumer/KafkaReceiver.java
+++ b/samples/sample-clients/kafka-avro-consumer/src/main/java/io/siddhi/distribution/sample/kafka/avro/consumer/KafkaReceiver.java
@@ -21,13 +21,14 @@ package io.siddhi.distribution.sample.kafka.avro.consumer;
 
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Test server for Kafka sink.
  */
 public class KafkaReceiver {
-    private static final Logger log = Logger.getLogger(KafkaReceiver.class);
+    private static final Logger log = LogManager.getLogger(KafkaReceiver.class);
 
     /**
      * Main method to start the test server.

--- a/samples/sample-clients/kafka-consumer/src/main/java/io/siddhi/distribution/sample/kafka/consumer/KafkaReceiver.java
+++ b/samples/sample-clients/kafka-consumer/src/main/java/io/siddhi/distribution/sample/kafka/consumer/KafkaReceiver.java
@@ -21,13 +21,14 @@ package io.siddhi.distribution.sample.kafka.consumer;
 
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Test server for Kafka sink.
  */
 public class KafkaReceiver {
-    private static final Logger log = Logger.getLogger(KafkaReceiver.class);
+    private static final Logger log = LogManager.getLogger(KafkaReceiver.class);
 
     /**
      * Main method to start the test server.

--- a/samples/sample-clients/kafka-producer/src/main/java/io/siddhi/distribution/sample/kafka/client/EventSendingUtil.java
+++ b/samples/sample-clients/kafka-producer/src/main/java/io/siddhi/distribution/sample/kafka/client/EventSendingUtil.java
@@ -19,7 +19,8 @@
 package io.siddhi.distribution.sample.kafka.client;
 
 import io.siddhi.core.stream.input.InputHandler;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,7 +32,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * Event generating util class for kafka source.
  */
 public class EventSendingUtil {
-    private static final Logger log = Logger.getLogger(EventSendingUtil.class);
+    private static final Logger log = LogManager.getLogger(EventSendingUtil.class);
     public static void publishEvents(List<String[]> fileEntriesList, boolean sendEventsContinuously,
                                      int noOfEventsToSend, String eventDefinition, String[] sweetName,
                                      InputHandler inputHandler, int delay, boolean isBinaryMessage,

--- a/samples/sample-clients/kafka-producer/src/main/java/io/siddhi/distribution/sample/kafka/client/KafkaClient.java
+++ b/samples/sample-clients/kafka-producer/src/main/java/io/siddhi/distribution/sample/kafka/client/KafkaClient.java
@@ -20,7 +20,8 @@ package io.siddhi.distribution.sample.kafka.client;
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.stream.input.InputHandler;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,7 +35,7 @@ import java.util.Scanner;
  */
 public class KafkaClient {
 
-    private static Logger log = Logger.getLogger(KafkaClient.class);
+    private static Logger log = LogManager.getLogger(KafkaClient.class);
     private static final String EMPTY_STRING = "EMPTY";
 
     /**

--- a/samples/sample-clients/prometheus-client/pom.xml
+++ b/samples/sample-clients/prometheus-client/pom.xml
@@ -31,8 +31,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.log4j.wso2</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.siddhi</groupId>

--- a/samples/sample-clients/tcp-client/src/main/java/io/siddhi/distribution/sample/tcp/client/EventSendingUtil.java
+++ b/samples/sample-clients/tcp-client/src/main/java/io/siddhi/distribution/sample/tcp/client/EventSendingUtil.java
@@ -19,7 +19,8 @@
 package io.siddhi.distribution.sample.tcp.client;
 
 import io.siddhi.core.stream.input.InputHandler;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,7 +32,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * Event generating util class for tcp source.
  */
 public class EventSendingUtil {
-    private static final Logger log = Logger.getLogger(EventSendingUtil.class);
+    private static final Logger log = LogManager.getLogger(EventSendingUtil.class);
     public static void publishEvents(List<String[]> fileEntriesList, boolean sendEventsContinuously,
                                      int noOfEventsToSend, String eventDefinition, String[] sweetName,
                                      InputHandler inputHandler, int delay, boolean isBinaryMessage,

--- a/samples/sample-clients/tcp-client/src/main/java/io/siddhi/distribution/sample/tcp/client/StoreTestClient.java
+++ b/samples/sample-clients/tcp-client/src/main/java/io/siddhi/distribution/sample/tcp/client/StoreTestClient.java
@@ -23,7 +23,8 @@ import io.siddhi.core.exception.ConnectionUnavailableException;
 import io.siddhi.extension.io.tcp.transport.TCPNettyClient;
 import io.siddhi.extension.map.binary.sinkmapper.BinaryEventConverter;
 import io.siddhi.query.api.definition.Attribute;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -35,7 +36,7 @@ import java.util.List;
 public class StoreTestClient {
     private static final String STREAM_NAME = "TestData";
     private static final Attribute.Type[] TYPES = new Attribute.Type[]{Attribute.Type.BOOL};
-    private static final Logger LOG = Logger.getLogger(StoreTestClient.class);
+    private static final Logger LOG = LogManager.getLogger(StoreTestClient.class);
 
     /**
      * Main method to start the test client.

--- a/samples/sample-clients/tcp-client/src/main/java/io/siddhi/distribution/sample/tcp/client/TCPClient.java
+++ b/samples/sample-clients/tcp-client/src/main/java/io/siddhi/distribution/sample/tcp/client/TCPClient.java
@@ -21,7 +21,8 @@ package io.siddhi.distribution.sample.tcp.client;
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.stream.input.InputHandler;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,7 +35,7 @@ import java.util.Scanner;
  * This is a sample TCP client to publish events to TCP endpoint.
  */
 public class TCPClient {
-    private static final Logger log = Logger.getLogger(TCPClient.class);
+    private static final Logger log = LogManager.getLogger(TCPClient.class);
     private static final String EMPTY_STRING = "EMPTY";
 
     /**

--- a/samples/sample-clients/tcp-server/src/main/java/io/siddhi/distribution/sample/tcp/server/TCPServer.java
+++ b/samples/sample-clients/tcp-server/src/main/java/io/siddhi/distribution/sample/tcp/server/TCPServer.java
@@ -21,7 +21,8 @@ package io.siddhi.distribution.sample.tcp.server;
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.util.config.InMemoryConfigManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,7 +32,7 @@ import java.util.Map;
  * Test Server for TCP source.
  */
 public class TCPServer {
-    private static Logger log = Logger.getLogger(TCPServer.class);
+    private static Logger log = LogManager.getLogger(TCPServer.class);
 
     /**
      * Main method to start the test Server.

--- a/samples/sample-clients/websocket-producer/src/main/java/io/siddhi/distribution/sample/websocket/server/EventSendingUtil.java
+++ b/samples/sample-clients/websocket-producer/src/main/java/io/siddhi/distribution/sample/websocket/server/EventSendingUtil.java
@@ -19,7 +19,8 @@
 package io.siddhi.distribution.sample.websocket.server;
 
 import io.siddhi.core.stream.input.InputHandler;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,7 +32,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * Event generating util class for websocket source.
  */
 public class EventSendingUtil {
-    private static final Logger log = Logger.getLogger(EventSendingUtil.class);
+    private static final Logger log = LogManager.getLogger(EventSendingUtil.class);
 
     public static void publishEvents(List<String[]> fileEntriesList, boolean sendEventsContinuously,
                                      int noOfEventsToSend, String eventDefinition, String[] sweetName,

--- a/samples/sample-clients/websocket-producer/src/main/java/io/siddhi/distribution/sample/websocket/server/WebSocketProducer.java
+++ b/samples/sample-clients/websocket-producer/src/main/java/io/siddhi/distribution/sample/websocket/server/WebSocketProducer.java
@@ -21,7 +21,8 @@ package io.siddhi.distribution.sample.websocket.server;
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.stream.input.InputHandler;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,7 +35,7 @@ import java.util.Scanner;
  * This is a sample WebSocket to publish events to endpoint.
  */
 public class WebSocketProducer {
-    private static final Logger log = Logger.getLogger(WebSocketProducer.class);
+    private static final Logger log = LogManager.getLogger(WebSocketProducer.class);
     private static final String EMPTY_STRING = "EMPTY";
 
     /**

--- a/samples/sample-clients/websocket-receiver/src/main/java/io/siddhi/distribution/sample/websocket/receiver/WebSocketReceiver.java
+++ b/samples/sample-clients/websocket-receiver/src/main/java/io/siddhi/distribution/sample/websocket/receiver/WebSocketReceiver.java
@@ -21,13 +21,14 @@ package io.siddhi.distribution.sample.websocket.receiver;
 
 import io.siddhi.core.SiddhiAppRuntime;
 import io.siddhi.core.SiddhiManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Test server for WebSocket source.
  */
 public class WebSocketReceiver {
-    private static final Logger log = Logger.getLogger(WebSocketReceiver.class);
+    private static final Logger log = LogManager.getLogger(WebSocketReceiver.class);
 
     /**
      * Main method to start the test server.

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/util/SourceEditorUtils.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/util/SourceEditorUtils.java
@@ -35,7 +35,8 @@ import io.siddhi.distribution.editor.core.util.designview.constants.SiddhiCodeBu
 import io.siddhi.query.api.definition.AbstractDefinition;
 import io.siddhi.query.api.definition.AggregationDefinition;
 import io.siddhi.query.api.definition.StreamDefinition;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -60,7 +61,7 @@ import java.util.regex.Pattern;
  */
 public class SourceEditorUtils {
 
-    static final Logger LOGGER = Logger.getLogger(SourceEditorUtils.class);
+    private static final Logger LOGGER = LogManager.getLogger(SourceEditorUtils.class);
 
     private SourceEditorUtils() {
 

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/util/designview/utilities/ConfigBuildingUtilities.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/util/designview/utilities/ConfigBuildingUtilities.java
@@ -19,14 +19,15 @@
 package io.siddhi.distribution.editor.core.util.designview.utilities;
 
 import io.siddhi.query.api.SiddhiElement;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Has methods involved in converting Siddhi elements to Design view Config objects.
  */
 public class ConfigBuildingUtilities {
 
-    private static final Logger log = Logger.getLogger(ConfigBuildingUtilities.class);
+    private static final Logger log = LogManager.getLogger(ConfigBuildingUtilities.class);
 
     /**
      * Avoids Instantiation.

--- a/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/util/restclients/storequery/StoreQueryAPIHelper.java
+++ b/tooling/components/io.siddhi.distribution.editor.core/src/main/java/io/siddhi/distribution/editor/core/util/restclients/storequery/StoreQueryAPIHelper.java
@@ -19,7 +19,8 @@ package io.siddhi.distribution.editor.core.util.restclients.storequery;
 
 import feign.Response;
 import io.siddhi.distribution.editor.core.exception.SiddhiStoreQueryHelperException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.carbon.config.ConfigurationException;
 import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.transport.http.netty.contract.config.ListenerConfiguration;
@@ -32,7 +33,7 @@ import java.util.HashMap;
  */
 public class StoreQueryAPIHelper {
 
-    private static final Logger logger = Logger.getLogger(StoreQueryAPIHelper.class);
+    private static final Logger logger = LogManager.getLogger(StoreQueryAPIHelper.class);
     private static final String STORE_API_CONFIG = "storeRESTAPI";
     private ConfigProvider configProvider;
 

--- a/tooling/components/io.siddhi.distribution.event.simulator.core/src/main/java/io/siddhi/distribution/event/simulator/core/internal/generator/csv/util/FileUploader.java
+++ b/tooling/components/io.siddhi.distribution.event.simulator.core/src/main/java/io/siddhi/distribution/event/simulator/core/internal/generator/csv/util/FileUploader.java
@@ -28,7 +28,8 @@ import io.siddhi.distribution.event.simulator.core.util.LogEncoder;
 import org.apache.commons.io.FileExistsException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.wso2.msf4j.formparam.FileInfo;
 
 import java.io.File;
@@ -46,7 +47,7 @@ import java.util.stream.Collectors;
  */
 
 public class FileUploader {
-    private static final Logger log = Logger.getLogger(FileUploader.class);
+    private static final Logger log = LogManager.getLogger(FileUploader.class);
     private static final FileUploader fileUploader = new FileUploader(FileStore.getFileStore());
 
     /**

--- a/tooling/components/io.siddhi.distribution.event.simulator.core/src/main/java/io/siddhi/distribution/event/simulator/core/internal/generator/database/util/DatabaseConnector.java
+++ b/tooling/components/io.siddhi.distribution.event.simulator.core/src/main/java/io/siddhi/distribution/event/simulator/core/internal/generator/database/util/DatabaseConnector.java
@@ -25,7 +25,8 @@ import io.siddhi.distribution.event.simulator.core.exception.EventGenerationExce
 import io.siddhi.distribution.event.simulator.core.exception.SimulatorInitializationException;
 import io.siddhi.distribution.event.simulator.core.model.DBConnectionModel;
 import io.siddhi.distribution.event.simulator.core.util.LogEncoder;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -47,7 +48,7 @@ import java.util.Properties;
  */
 public class DatabaseConnector {
 
-    private static final Logger log = Logger.getLogger(DatabaseConnector.class);
+    private static final Logger log = LogManager.getLogger(DatabaseConnector.class);
     private static final String query_attribute_OnlyStartTime = "SELECT %s,%s FROM %s WHERE %s >= %d ORDER BY ABS(%s);";
     private static final String query_attribute_WithBothLimits = "SELECT %s,%s FROM %s WHERE %s >= %d AND %s <= %d " +
             "ORDER BY ABS(%s);";

--- a/tooling/components/io.siddhi.distribution.event.simulator.core/src/main/java/io/siddhi/distribution/event/simulator/core/internal/util/SimulationConfigUploader.java
+++ b/tooling/components/io.siddhi.distribution.event.simulator.core/src/main/java/io/siddhi/distribution/event/simulator/core/internal/util/SimulationConfigUploader.java
@@ -23,7 +23,8 @@ import io.siddhi.distribution.event.simulator.core.exception.FileAlreadyExistsEx
 import io.siddhi.distribution.event.simulator.core.exception.FileOperationsException;
 import io.siddhi.distribution.event.simulator.core.exception.InvalidConfigException;
 import io.siddhi.distribution.event.simulator.core.util.LogEncoder;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -38,7 +39,7 @@ import java.nio.file.Paths;
  * This class is responsible for saving, modifying and deleting the simulation configurations.
  */
 public class SimulationConfigUploader {
-    private static final Logger log = Logger.getLogger(SimulationConfigUploader.class);
+    private static final Logger log = LogManager.getLogger(SimulationConfigUploader.class);
     private static final SimulationConfigUploader configUploader =
             new SimulationConfigUploader();
 


### PR DESCRIPTION
## Purpose
Remove log4j 1 and move to 2.17.1

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

